### PR TITLE
Adding default for VersionEye token

### DIFF
--- a/src/Gush/Command/ConfigureCommand.php
+++ b/src/Gush/Command/ConfigureCommand.php
@@ -184,7 +184,9 @@ EOF
         $versionEyeToken = $dialog->askAndValidate(
             $output,
             'versioneye token: ',
-            $validator
+            $validator,
+            false,
+            'NO_TOKEN'
         );
 
         $this->config->merge(


### PR DESCRIPTION
Allowing for no value on this input. If no input is given, `$versionEyeToken` will be set as `NO_TOKEN`
