### PR TITLE
Attempt to show correct `Gush version` value

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -35,7 +35,7 @@
             "in": "vendor/herrera-io/phar-update/res"
         }
     ],
-    "git-version": "package_version",
+    "git-version": "@git-version@",
     "main": "bin/gush",
     "output": "gush-@git-version@.phar",
     "stub": true


### PR DESCRIPTION
After I installed Gush using `composer global require 'gushphp/gush=dev-master'` it shows `Gush version @package_version@`, but when I installed it via `curl -sS http://gushphp.org/installer | php` it shows correct version as `Gush version 1.3.9`.

I don't know how to verify that my fix actually works and don't have time for this now.
