### PR TITLE
it is either branch:push or b:fork or other that is tracking the master branch

### DIFF
--- a/src/Command/IssueTakeCommand.php
+++ b/src/Command/IssueTakeCommand.php
@@ -69,7 +69,11 @@ EOF
                 'allow_failures' => true
             ],
             [
-                'line' => sprintf('git checkout -b %s %s/%s', $slugTitle, 'origin', $baseBranch),
+                'line' => sprintf('git checkout %s/%s', 'origin', $baseBranch),
+                'allow_failures' => true
+            ],
+            [
+                'line' => sprintf('git checkout -b %s', $slugTitle),
                 'allow_failures' => true
             ],
         ];


### PR DESCRIPTION
please check this weird issue, it is having me to go into .git/config and edit the reference which is always being pointed to the master branch
