### PR TITLE
bug when not using --source-org and --source-branch on PR command

### DIFF
--- a/src/Command/PullRequestCreateCommand.php
+++ b/src/Command/PullRequestCreateCommand.php
@@ -106,7 +106,7 @@ EOF
         $template = $input->getOption('template');
 
         if (null === $sourceOrg) {
-            $sourceOrg = $this->getHelper('git')->getVendorName();
+            $sourceOrg = $this->getParameter('authentication')['username'];
         }
 
         if (null === $sourceBranch) {


### PR DESCRIPTION
@Padam87 you did not check the command without arguments if it was still working

it is not working, can you please launch a PR fixing this? Thanks

```
  [Github\Exception\ValidationFailedException]
  Validation Failed: Field "head_sha" is missing, for resource "PullRequest", Field "base_sh
  a" is missing, for resource "PullRequest", No commits between gushphp:master and gushphp:8
  9-it-is-either-branch-push-or-b-fork-or-other-that-is-tracking-the-master-branch

```
