### PR TITLE
Allow repos without .git in url

### DIFF
--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -50,8 +50,8 @@ class GitHelper extends Helper
         if (!in_array('Fetch', $outputLines)) {
             foreach ($outputLines as $line) {
                 if ($line && preg_match('{^  Fetch URL: (.+@)*([\w\d\.]+):(.*)}', $line, $match)) {
-                    preg_match('{(.+/)(.+).git}', $match[3], $secondMatch);
-                    $foundRepoName = $secondMatch[2];
+                    preg_match('{(.+/)(.+)[.git]?}', $match[3], $secondMatch);
+                    $foundRepoName = str_replace('.git', '', $secondMatch[2]);
                     break;
                 }
             }
@@ -74,7 +74,7 @@ class GitHelper extends Helper
         if (!in_array('Fetch', $outputLines)) {
             foreach ($outputLines as $line) {
                 if ($line && preg_match('{^  Fetch URL: (.+@)*([\w\d\.]+):(.*)}', $line, $match)) {
-                    preg_match('{(.+/)(.+).git}', $match[3], $secondMatch);
+                    preg_match('{(.+/)(.+)[.git]?}', $match[3], $secondMatch);
                     $exploded = explode('/', $secondMatch[1]);
                     $foundVendorName = $exploded[count($exploded) - 2];
                     break;


### PR DESCRIPTION
Allow urls without .git (E.G https://github.com/gushphp/gush.git vs https://github.com/gushphp/gush) in the `getVendorName` and `getRepoName` methods
