### PR TITLE
Add option for local meta header

### DIFF
--- a/.gush.yml
+++ b/.gush.yml
@@ -1,0 +1,2 @@
+adapter: github
+meta-header: "This file is part of Gush package.\n\n(c) 2013-2014 Luis Cordova <cordoval@gmail.com>\n\nThis source file is subject to the MIT license that is bundled\nwith this source code in the file LICENSE."

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -38,6 +38,12 @@ class InitCommand extends BaseCommand
                 InputOption::VALUE_OPTIONAL,
                 "What adapter should be used? (github, bitbucket, gitlab)"
             )
+            ->addOption(
+                'meta',
+                'm',
+                InputOption::VALUE_NONE,
+                "Add a local meta template"
+            )
             ->setHelp(
                 <<<EOF
 The <info>%command.name%</info> configure parameters Gush will use:
@@ -95,6 +101,10 @@ EOF
             'adapter' => $adapterName
         ];
 
+        if ($input->getOption('meta')) {
+            $params['meta-header'] = $this->getMetaHeader($output);
+        }
+
         if (file_exists($filename)) {
             $params = array_merge(Yaml::parse(file_get_contents($filename)), $params);
         }
@@ -106,5 +116,22 @@ EOF
         $output->writeln('<info>Configuration file saved successfully.</info>');
 
         return self::COMMAND_SUCCESS;
+    }
+
+    private function getMetaHeader($output)
+    {
+        $template = $this->getHelper('template');
+        $available = $template->getNamesForDomain('meta-header');
+        $dialog = $this->getHelper('dialog');
+
+        $selection = $dialog->select(
+            $output,
+            'Choose License: ',
+            $available
+        );
+
+        $metaHeader = $this->getHelper('template')->askAndRender($output, 'meta-header', $available[$selection]);
+
+        return $metaHeader;
     }
 }

--- a/src/Command/MetaHeaderCommand.php
+++ b/src/Command/MetaHeaderCommand.php
@@ -26,6 +26,12 @@ class MetaHeaderCommand extends BaseCommand implements TemplateFeature
         $this
             ->setName('meta:header')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not change anything, output files')
+            ->addOption(
+                'no-local',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not use the local meta header if it is available'
+            )
             ->setHelp(
                 <<<EOT
 The <info>%command.name%</info> command asserts that headers are present
@@ -65,7 +71,11 @@ EOT
         $dryRun = $input->getOption('dry-run');
         $template = $input->getOption('template');
 
-        $metaHeader = $this->getHelper('template')->askAndRender($output, 'meta-header', $template);
+        $config = $this->getApplication()->getConfig();
+
+        if (null === ($metaHeader = $config->get('meta-header')) || $input->getOption('no-local')) {
+            $metaHeader = $this->getHelper('template')->askAndRender($output, 'meta-header', $template);
+        }
 
         $allFiles = $this->getHelper('git')->listFiles();
         $meta = $this->getHelper('meta');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | n |
| New Feature? | y |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | n |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |

When doing gush init, add option to save a local copy of the meta file. So when you run gush meta:header, it uses the local template so you don't have to add the package name etc each time
