### PR TITLE
The "pull-request:squash" don't assert preconditions

### DIFF
--- a/src/Command/PullRequestSquashCommand.php
+++ b/src/Command/PullRequestSquashCommand.php
@@ -37,6 +37,7 @@ class PullRequestSquashCommand extends BaseCommand implements GitHubFeature
 The <info>%command.name%</info> command squashes all commits of a PR:
 
     <info>$ gush %command.full_name% 12</info>
+
 EOF
             )
         ;
@@ -48,14 +49,18 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $prNumber = $input->getArgument('pr_number');
-
         $adapter = $this->getAdapter();
         $pr = $adapter->getPullRequest($prNumber);
+
+        $username = $this->getParameter('authentication')['username'];
+        if ($pr['head']['user']['login'] !== $username) {
+            $output->writeln('You cannot squash PRs not your own.');
+
+            return self::COMMAND_FAILURE;
+        }
+
         $base = $pr['base']['ref'];
         $head = $pr['head']['ref'];
-
-        $credentials = $this->getParameter('authentication');
-        $username = $credentials['username'];
 
         $commands = [
             [


### PR DESCRIPTION
Here is what I do:
- I'm the owner of the repo
- I'm running `pull-request:list` to see all pull requests to my repo
- I discover pull request sent by other contributor
- issue `pull-request:squash` command
- command fails because I don't have push access to contributor repo

I think that before doing anything we must verify push access to the repo we're trying to squash.

I suppose that `pull-request:squash` command was meant for my own PRs.
