### PR TITLE
Show Git commands in verbose mode

### DIFF
--- a/src/Helper/ProcessHelper.php
+++ b/src/Helper/ProcessHelper.php
@@ -64,9 +64,17 @@ class ProcessHelper extends Helper implements OutputAwareInterface
             ->setTimeout(3600)
         ;
         $process = $builder->getProcess();
+
+        $remover = function ($untrimmed) {
+            return ltrim(rtrim($untrimmed, "'"), "'");
+        };
         if ($this->output instanceof OutputInterface) {
-            $this->output->writeln($process->getCommandLine());
+            if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                $commandLine = implode(' ', array_map($remover, explode(' ', $process->getCommandLine())));
+                $this->output->writeln('<comment>OUT ></comment> ' . $commandLine);
+            }
         }
+
         $process->run($callback);
 
         if (!$process->isSuccessful() && !$allowFailures) {


### PR DESCRIPTION
For newcomers it will be easier to understand what Gush is doing by showing executed Git commands to them. I think we either can enable that mode by default or only when `-v` argument was supplied.
