### PR TITLE
The "branch:sync" command output shows error when no error found

### DIFF
--- a/src/Helper/ProcessHelper.php
+++ b/src/Helper/ProcessHelper.php
@@ -71,7 +71,7 @@ class ProcessHelper extends Helper implements OutputAwareInterface
         if ($this->output instanceof OutputInterface) {
             if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
                 $commandLine = implode(' ', array_map($remover, explode(' ', $process->getCommandLine())));
-                $this->output->writeln('<question>CMD ></question> '.$commandLine);
+                $this->output->writeln('<question>CMD</question> '.$commandLine);
             }
         }
 
@@ -110,9 +110,9 @@ class ProcessHelper extends Helper implements OutputAwareInterface
 
         $callback = function ($type, $buffer) use ($output) {
             if (Process::ERR === $type) {
-                $output->write('<info>OUT ></info> '.$buffer);
+                $output->write('<info>OUT</info> '.$buffer);
             } else {
-                $output->write('<comment>OUT ></comment> '.$buffer);
+                $output->write('<comment>OUT</comment> '.$buffer);
             }
         };
 


### PR DESCRIPTION
I run `gush b:s` inside Gush repo clone and get following output (see image):
![gush_branchsync_output](https://cloud.githubusercontent.com/assets/1277526/2832715/b7b78f0c-cfc7-11e3-97ea-e23e32aa1a19.png)

I don't know what determines if there is yellow `OUT>` or red `ERR>` prefix before line but it clearly reports good stuff like regular Git output as errors.

Transcript:

```
OUT > Fetching origin
OUT > Fetching aik099
ERR > From github.com:aik099/gush
 * [new branch]      master     -> aik099/master
ERR > Already on 'master'
OUT > Your branch is up-to-date with 'origin/master'.
OUT > HEAD is now at 487a3b3 make pass crazy test
ERR > From github.com:gushphp/gush
 * branch            master     -> FETCH_HEAD
OUT > First, rewinding head to replay your work on top of it...
OUT > Fast-forwarded master to c915e766645f43b57e170899762266018a7f788f.
ERR > Already on 'master'
OUT > Your branch is up-to-date with 'origin/master'.
Branch master has been synced upstream!
```
