### PR TITLE
[WIP] Check if remote upstream is configured for pull requests

### DIFF
--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -75,7 +75,9 @@ class GitHelper extends Helper
      */
     public function getVendorName()
     {
-        $output = $this->processHelper->runCommand('git remote show -n origin');
+        $remotes = $this->splitLines($this->processHelper->runCommand('git remote'));
+        $remote = in_array('upstream', $remotes, true) ? 'upstream' : 'origin';
+        $output = $this->processHelper->runCommand(sprintf('git remote show -n %s', $remote));
 
         $outputLines = $this->splitLines(trim($output));
 


### PR DESCRIPTION
When creating a pull request, we should first check if a remote upstream is configured, and use that for the PR. If not, just fall back to origin
