### PR TITLE
Issues running tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+# Always use LF
+core.autocrlf=lf


### PR DESCRIPTION
When I run the tests on Windows some assertions fail because of the line-ending difference, because Git uses the line-ending of the OS its not possible to safely rely on this to always work.

Instead the output should be converted to LF, and files being marked as LF using .gitattribute  I'm done for today, so I'll work on this tomorrow (unless anyone else wants to fix this :) )

```
* text=auto

# Always use LF
core.autocrlf=lf
```
