### PR TITLE
Add link to issues

### DIFF
--- a/src/Command/IssueListCommand.php
+++ b/src/Command/IssueListCommand.php
@@ -118,7 +118,7 @@ EOF
         }
 
         $table = $this->getHelper('table');
-        $table->setHeaders(['#', 'State', 'PR?', 'Title', 'User', 'Assignee', 'Milestone', 'Labels', 'Created']);
+        $table->setHeaders(['#', 'State', 'PR?', 'Title', 'User', 'Assignee', 'Milestone', 'Labels', 'Created', 'Link']);
 
         $table->formatRows($issues, function ($issue) {
             $labels = array_map(function ($label) {
@@ -135,6 +135,7 @@ EOF
                 $this->getHelper('text')->truncate($issue['milestone']['title'], 15),
                 $this->getHelper('text')->truncate(implode(',', $labels), 30),
                 date('Y-m-d', strtotime($issue['created_at'])),
+                $issue['html_url'],
             ];
         });
 

--- a/src/Command/IssueShowCommand.php
+++ b/src/Command/IssueShowCommand.php
@@ -78,6 +78,7 @@ EOF
             $output->writeln('Labels: '.implode(', ', $labels));
         }
         $output->writeln('Title: '.$issue['title']);
+        $output->writeln('Link: '.$issue['html_url']);
         $output->writeln('');
         $output->writeln($issue['body']);
 

--- a/src/Command/PullRequestListCommand.php
+++ b/src/Command/PullRequestListCommand.php
@@ -81,7 +81,7 @@ EOF
         $pullRequests = $adapter->getPullRequests($state);
 
         $table = $this->getHelper('table');
-        $table->setHeaders(['ID', 'Title', 'State', 'Created', 'User']);
+        $table->setHeaders(['ID', 'Title', 'State', 'Created', 'User', 'Link']);
         $table->formatRows($pullRequests, $this->getRowBuilderCallback());
         $table->setFooter(sprintf('%s pull request(s)', count($pullRequests)));
         $table->render($output, $table);
@@ -98,6 +98,7 @@ EOF
                 ucfirst($release['state']),
                 $release['created_at'],
                 $release['head']['user']['login'],
+                $release['html_url'],
             ];
         };
     }

--- a/src/Tester/Adapter/TestAdapter.php
+++ b/src/Tester/Adapter/TestAdapter.php
@@ -109,6 +109,7 @@ class TestAdapter extends BaseAdapter
                 'assignee'   => ['login' => 'cordoval'],
                 'milestone'  => ['title' => 'some good stuff release'],
                 'created_at' => '1969-12-31',
+                'html_url'   => $this->getIssueUrl('1'),
             ],
             [
                 'number'     => '2',
@@ -120,6 +121,7 @@ class TestAdapter extends BaseAdapter
                 'assignee'   => ['login' => 'cordoval'],
                 'milestone'  => ['title' => 'some good stuff release'],
                 'created_at' => '1969-12-31',
+                'html_url'   => $this->getIssueUrl('2'),
             ],
         ];
     }
@@ -205,7 +207,8 @@ class TestAdapter extends BaseAdapter
             'title'        => 'Write a behat test to launch strategy',
             'body'         => 'Help me conquer the world. Teach them to use gush.',
             'base'         => ['label' => 'master', 'ref' => 'base_ref'],
-            'head'         => ['ref' => 'head_ref', 'user' => ['login' => 'cordoval']]
+            'head'         => ['ref' => 'head_ref', 'user' => ['login' => 'cordoval']],
+            'link'         => 'https://github.com/gushphp/gush/pull/'.self::PULL_REQUEST_NUMBER,
         ];
     }
 

--- a/tests/Fixtures/OutputFixtures.php
+++ b/tests/Fixtures/OutputFixtures.php
@@ -29,11 +29,11 @@ class OutputFixtures
 EOT;
 
     const PULL_REQUEST_LIST = <<<EOT
-+----+-------------------+-------+---------------------+-----------+
-| ID | Title             | State | Created             | User      |
-+----+-------------------+-------+---------------------+-----------+
-| 17 | New feature added | Open  | 2014-04-14 17:24:12 | pierredup |
-+----+-------------------+-------+---------------------+-----------+
++----+-------------------+-------+---------------------+-----------+-------------------------------------------+
+| ID | Title             | State | Created             | User      | Link                                      |
++----+-------------------+-------+---------------------+-----------+-------------------------------------------+
+| 17 | New feature added | Open  | 2014-04-14 17:24:12 | pierredup | https://github.com/gushphp/gush/issues/17 |
++----+-------------------+-------+---------------------+-----------+-------------------------------------------+
 
 1 pull request(s)
 
@@ -45,17 +45,18 @@ Type: Pull Request
 Milestone: Conquer the world
 Labels: actionable, easy pick
 Title: Write a behat test to launch strategy
+Link: https://github.com/gushphp/gush/issues/60
 
 Help me conquer the world. Teach them to use gush.
 EOT;
 
     const ISSUE_LIST = <<<EOT
-+---+-------+-----+------------+------------+----------+-----------------+------------------+------------+
-| # | State | PR? | Title      | User       | Assignee | Milestone       | Labels           | Created    |
-+---+-------+-----+------------+------------+----------+-----------------+------------------+------------+
-| 1 | open  |     | easy issue | cordoval   | cordoval | some good st... | critic,easy pick | 1969-12-31 |
-| 2 | open  |     | hard issue | weaverryan | cordoval | some good st... | critic           | 1969-12-31 |
-+---+-------+-----+------------+------------+----------+-----------------+------------------+------------+
++---+-------+-----+------------+------------+----------+-----------------+------------------+------------+------------------------------------------+
+| # | State | PR? | Title      | User       | Assignee | Milestone       | Labels           | Created    | Link                                     |
++---+-------+-----+------------+------------+----------+-----------------+------------------+------------+------------------------------------------+
+| 1 | open  |     | easy issue | cordoval   | cordoval | some good st... | critic,easy pick | 1969-12-31 | https://github.com/gushphp/gush/issues/1 |
+| 2 | open  |     | hard issue | weaverryan | cordoval | some good st... | critic           | 1969-12-31 | https://github.com/gushphp/gush/issues/2 |
++---+-------+-----+------------+------------+----------+-----------------+------------------+------------+------------------------------------------+
 
 2 issues
 EOT;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | n |
| New Feature? | y |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | y |
| Fixed Tickets | #180 |
| License | MIT |
| Doc PR |  |

This is a simple change to add links when viewing issues or PR's.
On OSX links can be opened by using `CMD + double link` on the link

 Sent using [Gush](https://github.com/gushphp/gush)
