### PR TITLE
Fix EditorHelper for Windows

### DIFF
--- a/src/Helper/EditorHelper.php
+++ b/src/Helper/EditorHelper.php
@@ -13,6 +13,7 @@ namespace Gush\Helper;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Helper for launching external editor
@@ -48,7 +49,16 @@ class EditorHelper extends Helper
             throw new \RuntimeException('No EDITOR environment variable set.');
         }
 
-        system($editor.' '.$tmpName.' > `tty`');
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $process = ProcessBuilder::create([$editor, $tmpName])->getProcess();
+            $process->setTimeout(null);
+            $process->start();
+
+            // Wait till editor closes
+            $process->wait();
+        } else {
+            system($editor.' '.$tmpName.' > `tty`');
+        }
 
         $contents = file_get_contents($tmpName);
         $fs->remove($tmpName);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | y |
| New Feature? | n |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | y |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |

EditorHelper doesn't work on Windows because of the lack of tty.

There is however one small catch with this, if you're editor requires parameters like notepad++ with ' -multiInst -nosession' this will not work. Instead you have to create a cmd-file which contains the command and parameters like ``"C:\Program Files (x86)\Notepad++\notepad++.exe" -multiInst -nosession %1` and then change your editor-env value to point to the cmd-file.

Then it works.

Sent using [Gush](https://github.com/gushphp/gush)
