### PR TITLE
Update VersionEye Command

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -389,7 +389,7 @@ class Application extends BaseApplication
             new Cmd\PullRequest\PullRequestLabelListCommand(),
             new Cmd\PullRequest\PullRequestMilestoneListCommand(),
             new Cmd\PullRequest\PullRequestFixerCommand(),
-            new Cmd\PullRequest\PullRequestVersionEyeCommand(),
+            new Cmd\Util\VersionEyeCommand(),
             new Cmd\Util\FabbotIoCommand(),
             new Cmd\Util\MetaHeaderCommand(),
             new Cmd\Release\ReleaseCreateCommand(),

--- a/tests/Command/VersionEyeCommandTest.php
+++ b/tests/Command/VersionEyeCommandTest.php
@@ -11,18 +11,18 @@
 
 namespace Gush\Tests\Command;
 
-use Gush\Command\PullRequest\PullRequestVersionEyeCommand;
+use Gush\Command\Util\VersionEyeCommand;
 use Gush\Tests\Fixtures\OutputFixtures;
 
 /**
  * @author Luis Cordova <cordoval@gmail.com>
  */
-class PullRequestVersionEyeCommandTest extends BaseTestCase
+class VersionEyeCommandTest extends BaseTestCase
 {
     public function testCommand()
     {
         $processHelper = $this->expectProcessHelper();
-        $tester = $this->getCommandTester($command = new PullRequestVersionEyeCommand());
+        $tester = $this->getCommandTester($command = new VersionEyeCommand());
         $command->getHelperSet()->set($processHelper, 'process');
         $tester->execute(['--org' => 'gushphp', '--repo' => 'gush-sandbox'], ['interactive' => false]);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | n |
| New Feature? | Y |
| BC Breaks? | Y |
| Deprecations? | n |
| Tests Pass? | Y |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |
- Added stable option, to only update stable dependencies
- Moved the command to the Util namespace, as it's not really part of a pull request
- If the current project can't be found on VersionEye, give list of available projects for user to choose from
  
  Sent using [Gush](https://github.com/gushphp/gush)
