### PR TITLE
Add an exception for adapters' unsupported operations

### DIFF
--- a/src/Exception/UnsuportedOperationException.php
+++ b/src/Exception/UnsuportedOperationException.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of Gush.
+ *
+ * (c) Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Exception;
+
+/**
+ * Exception thrown by adapters when they do not support an operation
+ *
+ * @author Julien Bianchi <contact@jubianchi.fr>
+ */
+class UnsuportedOperationException extends AdapterException
+{
+}


### PR DESCRIPTION
As suggested in https://github.com/gushphp/gush-gitlab-adapter/pull/4#issuecomment-45412789
