### PR TITLE
Improve pull:merge with more details

### DIFF
--- a/src/Template/Messages.php
+++ b/src/Template/Messages.php
@@ -14,12 +14,12 @@ namespace Gush\Template;
 class Messages
 {
     const MERGE = <<<EOT
+{{ type }} #{{ prNumber }} {{ prTitle }} ({{ author }})
+
 This PR was merged into {{ baseBranch }} branch.
 
 Discussion
 ----------
-
-{{ prTitle }}
 
 {{ prBody }}
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | y |
| New Feature? | y |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | n |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |
- Fix the PR merge-commit title (which was completely wrong).
- PR title now includes the PR-number, type (optional)
  and author (username). When no type is given 'merge' is used instead
- Discussion has all trailing white space stripped
- A commit line only contains the first none-breaking line (subject)
  instead of all the details

Example:

``` markdown
merge #13 Testing PR merge with new title (sstok)

This PR was merged into master branch.

Discussion
----------

|Q |A |
|--- |---|
|Bug Fix? |y |
|New Feature? |y |
|BC Breaks? |y |
|Deprecations?|y |
|Tests Pass? |y |
|Fixed Tickets|y |
|License |MIT|
|Doc PR | |

Sent using [Gush](https://github.com/gushphp/gush)

Commits
-------

24e91896a4ab01e6c8bb6c72ffe863157396319d testing commit sstok
```

Sent using [Gush](https://github.com/gushphp/gush)
