### PR TITLE
Implement support for custom PR-table

### DIFF
--- a/.gush.yml
+++ b/.gush.yml
@@ -1,2 +1,10 @@
 adapter: github
 meta-header: "This file is part of Gush package.\n\n(c) 2013-2014 Luis Cordova <cordoval@gmail.com>\n\nThis source file is subject to the MIT license that is bundled\nwith this source code in the file LICENSE."
+table-pr:
+    bug_fix: ['Bug Fix?', no]
+    new_feature: ['New Feature?', no]
+    bc_breaks: ['BC Breaks?', no]
+    deprecations: ['Deprecations?', no]
+    tests_pass: ['Tests Pass?', no]
+    fixed_tickets: [Fixed Tickets, '']
+    license: [License, MIT]

--- a/src/Application.php
+++ b/src/Application.php
@@ -79,7 +79,7 @@ class Application extends BaseApplication
         $helperSet->set(new Helpers\ProcessHelper());
         $helperSet->set(new Helpers\EditorHelper());
         $helperSet->set(new Helpers\GitHelper($helperSet->get('process')));
-        $helperSet->set(new Helpers\TemplateHelper($helperSet->get('dialog')));
+        $helperSet->set(new Helpers\TemplateHelper($helperSet->get('dialog'), $this));
         $helperSet->set(new Helpers\MetaHelper($this->getSupportedMetaFiles()));
         $helperSet->set(new UpdateHelper());
 

--- a/src/Helper/TemplateHelper.php
+++ b/src/Helper/TemplateHelper.php
@@ -11,12 +11,14 @@
 
 namespace Gush\Helper;
 
+use Gush\Application;
 use Gush\Template\Meta\Header\GPL3Template;
 use Gush\Template\Meta\Header\MITTemplate;
 use Gush\Template\Meta\Header\NoLicenseTemplate;
 use Gush\Template\Pats\PatTemplate;
 use Gush\Template\PullRequest\Create\DefaultTemplate;
 use Gush\Template\PullRequest\Create\EnterpriseTemplate;
+use Gush\Template\PullRequest\Create\PullRequestCustomTemplate;
 use Gush\Template\PullRequest\Create\SymfonyDocTemplate;
 use Gush\Template\PullRequest\Create\SymfonyTemplate;
 use Gush\Template\PullRequest\Create\ZendFrameworkDocTemplate;
@@ -26,7 +28,6 @@ use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Input\InputAwareInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\Helper;
 
 class TemplateHelper extends Helper implements InputAwareInterface
@@ -36,11 +37,12 @@ class TemplateHelper extends Helper implements InputAwareInterface
     protected $dialog;
     protected $input;
 
-    public function __construct(HelperInterface $dialog)
+    public function __construct(HelperInterface $dialog, Application $application)
     {
         $this->registerTemplate(new SymfonyTemplate());
         $this->registerTemplate(new SymfonyDocTemplate());
         $this->registerTemplate(new EnterpriseTemplate());
+        $this->registerTemplate(new PullRequestCustomTemplate($application));
         $this->registerTemplate(new PatTemplate());
         $this->registerTemplate(new DefaultTemplate());
         $this->registerTemplate(new ZendFrameworkDocTemplate());

--- a/src/Template/PullRequest/Create/PullRequestCustomTemplate.php
+++ b/src/Template/PullRequest/Create/PullRequestCustomTemplate.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2014 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Template\PullRequest\Create;
+
+use Gush\Application;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class PullRequestCustomTemplate extends AbstractSymfonyTemplate
+{
+    /**
+     * @var \Gush\Application
+     */
+    private $application;
+
+    /**
+     * @param Application $application
+     */
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \RuntimeException when fields structure is invalid
+     */
+    public function getRequirements()
+    {
+        $fields = $this->application->getConfig()->get('table-pr') ?: [];
+        $fields['description'] = ['Description', ''];
+
+        if (count($fields) < 2) {
+            throw new \RuntimeException(
+                'table-pr structure requires at least one row, please check your local .gush.yml'
+            );
+        }
+
+        foreach ($fields as $name => $rowData) {
+            if (!is_string($name)) {
+                throw new \RuntimeException(
+                    'table-pr table row-name must be a string, please check your local .gush.yml'
+                );
+            }
+
+            if (!is_array($rowData) || count($rowData) <> 2) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'table-pr table row-data "%s" must be an array with exactly two values like: [Label, default value].'.
+                        "\n".'please check your local .gush.yml',
+                        $name
+                    )
+                );
+            }
+        }
+
+        return $fields;
+    }
+
+    public function getName()
+    {
+        return 'pull-request-create/custom';
+    }
+}

--- a/tests/Helper/TemplateHelperTest.php
+++ b/tests/Helper/TemplateHelperTest.php
@@ -29,7 +29,13 @@ class TemplateHelperTest extends \PHPUnit_Framework_TestCase
         $this->input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
         $this->template = $this->getMock('Gush\Template\TemplateInterface');
 
-        $this->helper = new TemplateHelper($this->dialog);
+        $application = $this->getMockBuilder('Gush\Application')
+            ->disableOriginalConstructor()
+            ->setMethods(['getConfig'])
+            ->getMock()
+        ;
+
+        $this->helper = new TemplateHelper($this->dialog, $application);
         $this->helper->setInput($this->input);
     }
 

--- a/tests/Template/PullRequest/Create/PullRequestCustomTemplateTest.php
+++ b/tests/Template/PullRequest/Create/PullRequestCustomTemplateTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2014 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Tests\Template\PullRequest\Create;
+
+use Gush\Template\PullRequest\Create\PullRequestCustomTemplate;
+
+class PullRequestCustomTemplateTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var PullRequestCustomTemplate */
+    protected $template;
+
+    /**
+     * @var \Gush\Application|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $application;
+
+    public function setUp()
+    {
+        $this->application = $this->getMockBuilder('Gush\Application')
+            ->disableOriginalConstructor()
+            ->setMethods(['getConfig'])
+            ->getMock()
+        ;
+
+        $this->template = new PullRequestCustomTemplate($this->application);
+    }
+
+    public function provideTemplate()
+    {
+        $spaces = '                   ';
+        $spaces2 = '                      ';
+
+        return [
+            [
+                [],
+                <<<EOF
+$spaces
+|Q            |A  |
+|---          |---|
+|Bug Fix?     |n  |
+|New Feature? |n  |
+|BC Breaks?   |n  |
+|Deprecations?|n  |
+|Tests Pass?  |n  |
+|Fixed Tickets|   |
+|License      |MIT|
+$spaces
+
+This is a description
+EOF
+            ],
+            [
+                [
+                    'bug_fix' => 'y',
+                    'new_feature' => 'yes',
+                    'bc_breaks' => 'yes',
+                    'deprecations' => 'yes',
+                    'tests_pass' => 'yes',
+                    'fixed_tickets' => 'none',
+                    'license' => 'Apache',
+                ],
+                <<<EOF
+$spaces2
+|Q            |A     |
+|---          |---   |
+|Bug Fix?     |y     |
+|New Feature? |yes   |
+|BC Breaks?   |yes   |
+|Deprecations?|yes   |
+|Tests Pass?  |yes   |
+|Fixed Tickets|none  |
+|License      |Apache|
+$spaces2
+
+This is a description
+EOF
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider provideTemplate
+     */
+    public function testTemplate($params, $expected)
+    {
+        $table = [
+            'bug_fix' => ['Bug Fix?', 'n'],
+            'new_feature' => ['New Feature?', 'n'],
+            'bc_breaks' => ['BC Breaks?', 'n'],
+            'deprecations' => ['Deprecations?', 'n'],
+            'tests_pass' => ['Tests Pass?', 'n'],
+            'fixed_tickets' => ['Fixed Tickets', ''],
+            'license' => ['License', 'MIT'],
+            'description' => ['Description', ''],
+        ];
+
+        $config = new \Gush\Config();
+        $config->merge([
+            'table-pr' => $table
+        ]);
+
+        $this->application
+            ->expects($this->atLeastOnce())
+            ->method('getConfig')
+            ->will($this->returnValue($config))
+        ;
+
+        $requirements = $this->template->getRequirements();
+
+        foreach ($requirements as $key => $requirement) {
+            list (, $default) = $requirement;
+            if (!isset($params[$key])) {
+                $params[$key] = $default;
+            }
+        }
+
+        $params['description'] = 'This is a description';
+
+        $this->template->bind($params);
+        $res = $this->template->render();
+        $this->assertEquals($expected, $res);
+    }
+
+    public function testErrorWithEmptyTable()
+    {
+        $config = new \Gush\Config();
+        $config->merge([
+            'table-pr' => []
+        ]);
+
+        $this->application
+            ->expects($this->atLeastOnce())
+            ->method('getConfig')
+            ->will($this->returnValue($config))
+        ;
+
+        $this->setExpectedException(
+            'RuntimeException',
+            'table-pr structure requires at least one row, please check your local .gush.yml'
+        );
+
+        $this->template->getRequirements();
+    }
+
+    public function testErrorWithNameNotAString()
+    {
+        $config = new \Gush\Config();
+        $config->merge([
+            'table-pr' => [
+                0 => ['Bug Fix?', 'n'],
+            ]
+        ]);
+
+        $this->application
+            ->expects($this->atLeastOnce())
+            ->method('getConfig')
+            ->will($this->returnValue($config))
+        ;
+
+        $this->setExpectedException(
+            'RuntimeException',
+            'table-pr table row-name must be a string, please check your local .gush.yml'
+        );
+
+        $this->template->getRequirements();
+    }
+
+    public function testErrorWithInvalidRow()
+    {
+        $config = new \Gush\Config();
+        $config->merge([
+            'table-pr' => [
+                'new_feature' => ['Bug Fix?', 'no'],
+                'bug_fix' => ['Bug Fix?'],
+            ]
+        ]);
+
+        $this->application
+            ->expects($this->atLeastOnce())
+            ->method('getConfig')
+            ->will($this->returnValue($config))
+        ;
+
+        $this->setExpectedException(
+            'RuntimeException',
+            'table-pr table row-data "bug_fix" must be an array with exactly two values like: [Label, default value].'.
+            "\n".'please check your local .gush.yml'
+        );
+
+        $this->template->getRequirements();
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | yes |
| BC Breaks? | no |
| Deprecations? | no |
| Tests Pass? | no |
| Fixed Tickets | #119 |
| License | MIT |

Allow PR-table to be repo oriented as discussed in #119, only "issue" is that using `--template=custom` is required to get the custom template to work.

The RepoCustomTemplate is Application-aware because of
late loading of the Configuration, in the future we can always improve this, but for now it works.

Small detail, I used this feature to open this PR :smile:                     

Sent using [Gush](https://github.com/gushphp/gush)
