### PR TITLE
add autocompletion for gush.phar

### DIFF
--- a/src/Helper/AutocompleteHelper.php
+++ b/src/Helper/AutocompleteHelper.php
@@ -44,7 +44,7 @@ _gush()
     return 0;
 }
 
-complete -o default -F _gush gush
+complete -o default -F _gush gush gush.phar
 COMP_WORDBREAKS=\${COMP_WORDBREAKS//:}
 
 EOL;


### PR DESCRIPTION
some people (like me) use phar executables without removing the file extension
