### PR TITLE
pull:create fails when using an older git version

### DIFF
--- a/bin/gush
+++ b/bin/gush
@@ -23,7 +23,12 @@ $process->run();
 if (!$process->isSuccessful()) {
     throw new \RuntimeException('Git is required.');
 }
-ladybug_dump_die($process->getOutput());
+
+$version = trim(explode(' ', $process->getOutput())[2]);
+if (version_compare($version, '1.9.1', 'lt')) {
+    throw new \RuntimeException('It is advisable to upgrade your version to 1.9.1 or latest.');
+}
+
 $adapterFactory = new Gush\Factory\AdapterFactory();
 
 $adapters = [


### PR DESCRIPTION
Since the resent change with getting the default title for the PR it fails on my system.
It seems `fork-point` was introduced in git 1.9 / 2.0 and does not exist in the version I'm using `1.8.4.msysgit.0`.

I can upgrade this version, but I'm not sure which Git version is provided with most Unix-type systems.
So should warn the user if the Git-version is to low or disable this behavior for such cases?
