### PR TITLE
Added "issue:copy" command

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -440,6 +440,7 @@ LOGO;
             new Cmd\Issue\IssueLabelListCommand(),
             new Cmd\Issue\IssueMilestoneListCommand(),
             new Cmd\Issue\IssueShowCommand(),
+            new Cmd\Issue\IssueCopyCommand(),
             new Cmd\Issue\IssueListCommand(),
             new Cmd\Issue\LabelIssuesCommand(),
             new Cmd\Branch\BranchPushCommand(),

--- a/src/Command/Issue/IssueCopyCommand.php
+++ b/src/Command/Issue/IssueCopyCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2014 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Command\Issue;
+
+use Gush\Command\BaseCommand;
+use Gush\Feature\GitRepoFeature;
+use Gush\Feature\TableFeature;
+use Gush\Helper\GitRepoHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Copy an issue from one repository to another
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class IssueCopyCommand extends BaseCommand implements GitRepoFeature
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('issue:copy')
+            ->setDescription('Copy issue')
+            ->addArgument('issue_number', InputArgument::REQUIRED, 'Issue number to move')
+            ->addArgument('target_username', InputArgument::REQUIRED, 'Target username or organization')
+            ->addArgument('target_repository', InputArgument::REQUIRED, 'Target repository')
+            ->addOption('prefix', null, InputOption::VALUE_REQUIRED, 'Prefix for the issue title')
+            ->addOption('close', null, InputOption::VALUE_NONE, 'Close original issue')
+            ->setHelp(
+                <<<EOF
+The <info>%command.name%</info> command moves an issue from one repository to another
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $issueNumber = $input->getArgument('issue_number');
+        $targetUsername = $input->getArgument('target_username');
+        $targetRepository = $input->getArgument('target_repository');
+        $prefix = $input->getOption('prefix') ? : '';
+        $close = $input->getOption('close');
+
+        $adapter = $this->getIssueTracker();
+
+        $srcIssue = $adapter->getIssue($issueNumber);
+        $srcTitle = $prefix . $srcIssue['title'];
+
+        $srcUsername = $adapter->getUsername();
+        $srcRepository = $adapter->getRepository();
+
+        $adapter->setUsername($targetUsername);
+        $adapter->setRepository($targetRepository);
+
+        $output->writeln(sprintf(
+            '  <info>%s/%s</info>: Opening issue "%s"',
+            $targetUsername,
+            $targetRepository,
+            $srcTitle
+        ));
+
+        $adapter->openIssue(
+            $srcTitle,
+            $srcIssue['body'],
+            $srcIssue
+        );
+
+        $adapter->setUsername($srcUsername);
+        $adapter->setRepository($srcRepository);
+
+        if (true === $close) {
+            $output->writeln(sprintf(
+                '  <info>%s/%s</info>: Closing issue "<info>%s</info>"',
+                $srcUsername,
+                $srcRepository,
+                $issueNumber
+            ));
+            $adapter->closeIssue($issueNumber);
+        }
+
+        return self::COMMAND_SUCCESS;
+    }
+}
+

--- a/tests/Command/Issue/IssueCopyCommandTest.php
+++ b/tests/Command/Issue/IssueCopyCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2014 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Tests\Command\Issue;
+
+use Gush\Command\Issue\IssueCopyCommand;
+use Gush\Tester\Adapter\TestAdapter;
+use Gush\Tests\Command\BaseTestCase;
+use Gush\Tests\Fixtures\OutputFixtures;
+
+class IssueCopyCommandTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    public function copies_an_issue()
+    {
+        $tester = $this->getCommandTester(new IssueCopyCommand());
+        $tester->execute([
+            '--org' => 'gushphp', 
+            '--repo' => 'gush',
+            'issue_number' => TestAdapter::ISSUE_NUMBER,
+            'target_username' => 'dantleech',
+            'target_repository' => 'gushphp',
+            '--prefix' => '[SomePrefix] ',
+            '--close' => true
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertEquals(OutputFixtures::ISSUE_COPY, trim($tester->getDisplay()));
+    }
+}

--- a/tests/Fixtures/OutputFixtures.php
+++ b/tests/Fixtures/OutputFixtures.php
@@ -72,6 +72,11 @@ EOT;
 Closed https://github.com/gushphp/gush/issues/7
 EOT;
 
+    const ISSUE_COPY = <<<EOT
+dantleech/gushphp: Opening issue "[SomePrefix] Write a behat test to launch strategy"
+  gushphp/gush: Closing issue "7"
+EOT;
+
     const PULL_REQUEST_CLOSE = <<<EOT
 Closed https://github.com/gushphp/gush/pull/40
 EOT;


### PR DESCRIPTION
This PR adds an `issue:copy` command.

It will copy issues from one repository to another.
- Can optionally close the source issue
- Can add a prefix to the subject of the "new" issue

todo
- Copy to the same repository (?) maybe the arguments should be options
