### PR TITLE
hotfix for IssueTakeCommand

### DIFF
--- a/src/Command/Issue/IssueTakeCommand.php
+++ b/src/Command/Issue/IssueTakeCommand.php
@@ -16,6 +16,7 @@ use Gush\Feature\GitRepoFeature;
 use Gush\Helper\GitHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class IssueTakeCommand extends BaseCommand implements GitRepoFeature
@@ -30,6 +31,13 @@ class IssueTakeCommand extends BaseCommand implements GitRepoFeature
             ->setDescription('Takes an issue')
             ->addArgument('issue_number', InputArgument::REQUIRED, 'Number of the issue')
             ->addArgument('base_branch', InputArgument::OPTIONAL, 'Name of the base branch to checkout from', 'master')
+            ->addOption(
+                'remote',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Name of the Git remote (default is origin)',
+                null
+            )
             ->setHelp(
                 <<<EOF
 The <info>%command.name%</info> command takes an issue from issue tracker repository list:
@@ -46,7 +54,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $org = $input->getOption('org') ?: 'origin';
+        $remote = $input->getOption('remote') ?: 'origin';
         $issueNumber = $input->getArgument('issue_number');
         $baseBranch = $input->getArgument('base_branch');
 
@@ -64,8 +72,8 @@ EOF
         $gitHelper = $this->getHelper('git');
         /** @var GitHelper $gitHelper */
 
-        $gitHelper->remoteUpdate($org);
-        $gitHelper->checkout($org.'/'.$baseBranch);
+        $gitHelper->remoteUpdate($remote);
+        $gitHelper->checkout($remote.'/'.$baseBranch);
         $gitHelper->checkout($slugTitle, true);
 
         $url = $tracker->getIssueUrl($issueNumber);

--- a/tests/Command/Issue/IssueTakeCommandTest.php
+++ b/tests/Command/Issue/IssueTakeCommandTest.php
@@ -26,9 +26,11 @@ class IssueTakeCommandTest extends BaseTestCase
      */
     public function takes_an_issue()
     {
+        $this->expectsConfig();
+
         $tester = $this->getCommandTester($command = new IssueTakeCommand());
         $command->getHelperSet()->set($this->expectTextHelper());
-        $command->getHelperSet()->set($this->expectGitHelper('gushphp', 'gushphp/master'));
+        $command->getHelperSet()->set($this->expectGitHelper('origin', 'origin/master'));
 
         $tester->execute(
             ['--org' => 'gushphp', '--repo' => 'gush', 'issue_number' => TestAdapter::ISSUE_NUMBER],
@@ -46,12 +48,36 @@ class IssueTakeCommandTest extends BaseTestCase
      */
     public function takes_an_issue_with_specific_base()
     {
+        $this->expectsConfig();
+
         $tester = $this->getCommandTester($command = new IssueTakeCommand());
         $command->getHelperSet()->set($this->expectTextHelper());
-        $command->getHelperSet()->set($this->expectGitHelper('gushphp', 'gushphp/development'));
+        $command->getHelperSet()->set($this->expectGitHelper('origin', 'origin/development'));
 
         $tester->execute(
             ['--org' => 'gushphp', 'issue_number' => TestAdapter::ISSUE_NUMBER, 'base_branch' => 'development'],
+            ['interactive' => false]
+        );
+
+        $this->assertEquals(
+            sprintf('Issue https://github.com/gushphp/gush/issues/%s taken!', TestAdapter::ISSUE_NUMBER),
+            trim($tester->getDisplay(true))
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function takes_an_issue_with_specific_remote()
+    {
+        $this->expectsConfig();
+
+        $tester = $this->getCommandTester($command = new IssueTakeCommand());
+        $command->getHelperSet()->set($this->expectTextHelper());
+        $command->getHelperSet()->set($this->expectGitHelper('gushphp', 'gushphp/master'));
+
+        $tester->execute(
+            ['--org' => 'gushphp', 'issue_number' => TestAdapter::ISSUE_NUMBER, '--remote' => 'gushphp'],
             ['interactive' => false]
         );
 
@@ -76,7 +102,7 @@ class IssueTakeCommandTest extends BaseTestCase
         return $text->reveal();
     }
 
-    private function expectGitHelper($remote = 'gushphp', $baseBranch = 'origin/master')
+    private function expectGitHelper($remote = 'origin', $baseBranch = 'origin/master')
     {
         $gitHelper = $this->prophet->prophesize('Gush\Helper\GitHelper');
         $gitHelper->setHelperSet(Argument::any())->shouldBeCalled();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed Tickets |  |
| License | MIT |

Org is also used for configuring the adapter, so unless a remote with the same
name as org exists you can't use this command.

The old situation always used 'origin', which is now configurable.
