### PR TITLE
fix PathFilterIterator Pattern conversion

### DIFF
--- a/src/Meta/Iterator/PathFilterIterator.php
+++ b/src/Meta/Iterator/PathFilterIterator.php
@@ -70,7 +70,7 @@ class PathFilterIterator extends BasePathFilterIterator
         if ($expression->isGlob()) {
             $regex = $expression->getRegex();
 
-            // We don't the starts-with operator '^'
+            // We don't need the starts-with operator '^'
             return $regex::BOUNDARY.substr($regex->render(), strlen($regex::BOUNDARY)+1);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed Tickets |  |
| License | MIT |

The default implementation simply escaped the pattern
but did not convert a glob pattern to a regex
