### PR TITLE
Adds shebang to "gush.phar" file

### DIFF
--- a/phar-stub.php
+++ b/phar-stub.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 /*


### PR DESCRIPTION
The `gush.phar` file, that installer downloads needs to be rebuilt for this change to take effect.

Closes #373