### PR TITLE
use organization for issue:take remote

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -98,7 +98,7 @@ LOGO;
         $helperSet->set(new Helpers\TableHelper());
         $helperSet->set(new Helpers\ProcessHelper());
         $helperSet->set(new Helpers\EditorHelper());
-        $helperSet->set(new Helpers\GitConfigHelper($helperSet->get('process')));
+        $helperSet->set(new Helpers\GitConfigHelper($helperSet->get('process'), $this));
         $helperSet->set(
             new Helpers\GitHelper(
                 $helperSet->get('process'),

--- a/src/Command/PullRequest/PullRequestMergeCommand.php
+++ b/src/Command/PullRequest/PullRequestMergeCommand.php
@@ -113,6 +113,8 @@ EOF
 
         $gitHelper = $this->getHelper('git');
         /** @var GitHelper $gitHelper */
+        $gitConfigHelper = $this->getHelper('git_config');
+        /** @var GitConfigHelper $gitConfigHelper */
 
         $sourceRemote = $pr['head']['user'];
         $sourceRepository = $pr['head']['repo'];
@@ -122,8 +124,8 @@ EOF
         $targetRepository = $pr['base']['repo'];
         $targetBranch = $pr['base']['ref'];
 
-        $this->ensureRemoteExists($targetRemote, $targetRepository);
-        $this->ensureRemoteExists($sourceRemote, $sourceRepository);
+        $gitConfigHelper->ensureRemoteExists($targetRemote, $targetRepository);
+        $gitConfigHelper->ensureRemoteExists($sourceRemote, $sourceRepository);
 
         try {
             $prType = $this->getPrType($prType);
@@ -182,23 +184,6 @@ EOF
             $gitHelper->restoreStashedBranch();
 
             return self::COMMAND_FAILURE;
-        }
-    }
-
-    private function ensureRemoteExists($org, $repo)
-    {
-        $gitConfigHelper = $this->getHelper('git_config');
-        /** @var GitConfigHelper $gitConfigHelper */
-
-        $adapter = $this->getAdapter();
-        $repoInfo = $adapter->getRepositoryInfo($org, $repo);
-
-        if (!$gitConfigHelper->remoteExists($org, $repoInfo['push_url'])) {
-            $this->getHelper('gush_style')->note(
-                sprintf('Adding remote "%s" with "%s".', $org, $repoInfo['fetch_url'])
-            );
-
-            $gitConfigHelper->setRemote($org, $repoInfo['push_url'], $repoInfo['push_url']);
         }
     }
 

--- a/src/Helper/GitConfigHelper.php
+++ b/src/Helper/GitConfigHelper.php
@@ -11,16 +11,25 @@
 
 namespace Gush\Helper;
 
+use Gush\Application;
 use Symfony\Component\Console\Helper\Helper;
 
 class GitConfigHelper extends Helper
 {
-    /** @var \Gush\Helper\ProcessHelper */
+    /**
+     * @var \Gush\Helper\ProcessHelper
+     */
     private $processHelper;
 
-    public function __construct(ProcessHelper $processHelper)
+    /**
+     * @var Application
+     */
+    private $application;
+
+    public function __construct(ProcessHelper $processHelper, Application $application)
     {
         $this->processHelper = $processHelper;
+        $this->application = $application;
     }
 
     /**
@@ -134,6 +143,26 @@ class GitConfigHelper extends Helper
 
         if ($pushUrl) {
             $this->setGitConfig('remote.'.$name.'.pushurl', $pushUrl, true);
+        }
+    }
+
+    /**
+     * Ensure the remote exist for the org and repo.
+     *
+     * @param string $org
+     * @param string $repo
+     */
+    public function ensureRemoteExists($org, $repo)
+    {
+        $adapter = $this->application->getAdapter();
+        $pushUrl = $adapter->getRepositoryInfo($org, $repo)['push_url'];
+
+        if (!$this->remoteExists($org, $pushUrl)) {
+            $this->getHelperSet()->get('gush_style')->note(
+                sprintf('Adding remote "%s" with "%s".', $org, $pushUrl)
+            );
+
+            $this->setRemote($org, $pushUrl, $pushUrl);
         }
     }
 

--- a/tests/Command/PullRequest/PullRequestMergeCommandTest.php
+++ b/tests/Command/PullRequest/PullRequestMergeCommandTest.php
@@ -67,26 +67,14 @@ Commits
 OET;
 
     const COMMAND_DISPLAY = <<<OET
-! [NOTE] Adding remote "gushphp" with "https://github.com/gushphp/gush.git".
-
-! [NOTE] Adding remote "cordoval" with "https://github.com/cordoval/gush.git".
-
 [OK] This PR was merged into the base_ref branch.
 OET;
 
     const FAILURE_TYPE_DISPLAY = <<<OET
-! [NOTE] Adding remote "gushphp" with "https://github.com/gushphp/gush.git".
-
-! [NOTE] Adding remote "cordoval" with "https://github.com/cordoval/gush.git".
-
 [ERROR] Pull-request type 'feat' is not accepted, choose of one of: security, feature, bug.
 OET;
 
     const COMMAND_DISPLAY_SQUASHED = <<<OET
-! [NOTE] Adding remote "gushphp" with "https://github.com/gushphp/gush.git".
-
-! [NOTE] Adding remote "cordoval" with "https://github.com/cordoval/gush.git".
-
 [OK] This PR was squashed before being merged into the base_ref branch (closes #40).
 OET;
 
@@ -279,20 +267,8 @@ OET;
         $this->gitConfig->getName()->willReturn('git_config');
         $this->gitConfig->setHelperSet(Argument::any())->shouldBeCalled();
 
-        $this->gitConfig->remoteExists('cordoval', 'git@github.com:cordoval/gush.git')->willReturn(false);
-        $this->gitConfig->remoteExists('gushphp', 'git@github.com:gushphp/gush.git')->willReturn(false);
-
-        $this->gitConfig->setRemote(
-            'cordoval',
-            'git@github.com:cordoval/gush.git',
-            'git@github.com:cordoval/gush.git'
-        )->shouldBeCalled();
-
-        $this->gitConfig->setRemote(
-            'gushphp',
-            'git@github.com:gushphp/gush.git',
-            'git@github.com:gushphp/gush.git'
-        )->shouldBeCalled();
+        $this->gitConfig->ensureRemoteExists('cordoval', 'gush')->shouldBeCalled();
+        $this->gitConfig->ensureRemoteExists('gushphp', 'gush')->shouldBeCalled();
 
         $helperSet = $application->getHelperSet();
         $helperSet->set($this->git->reveal());

--- a/tests/Helper/GitConfigHelperTest.php
+++ b/tests/Helper/GitConfigHelperTest.php
@@ -34,7 +34,10 @@ final class GitConfigHelperTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->processHelper = $this->getMock('Gush\Helper\ProcessHelper');
-        $this->gitConfigHelper = new GitConfigHelper($this->processHelper);
+        $this->gitConfigHelper = new GitConfigHelper(
+            $this->processHelper,
+            $this->getMockBuilder('Gush\Application')->disableOriginalConstructor()->getMock()
+        );
     }
 
     /**


### PR DESCRIPTION
                    
|Q            |A   |
|---          |--- |
|Fixed Tickets|None|
|License      |MIT |
                    

Use the (provided) organization for the remote of the `issue:take` command
instead of requiring this to be provided separately.

The `--remote` option is removed to prevent confusion
