### PR TITLE
Guard remote branch exists in pull-request:create

### DIFF
--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -199,6 +199,31 @@ class GitHelper extends Helper
     }
 
     /**
+     * @param string $remote Remote name or git-repository url
+     * @param string $branch
+     *
+     * @return bool
+     */
+    public function remoteBranchExists($remote, $branch)
+    {
+        $result = $this->processHelper->runCommand(['git', 'ls-remote', $remote], true);
+
+        return 1 === preg_match('#(?<=\s)'.preg_quote('refs/heads/'.$branch, '#').'(?!\w)#', $result);
+    }
+
+    /**
+     * @param string $branch
+     *
+     * @return bool
+     */
+    public function branchExists($branch)
+    {
+        $result = $this->processHelper->runCommand(['git', 'branch', '--list', $branch], true);
+
+        return 1 === preg_match('#'.preg_quote($branch, '#').'(?!\w)#', $result);
+    }
+
+    /**
      * @return string The vendor name
      */
     public function getVendorName()


### PR DESCRIPTION
                    
|Q            |A   |
|---          |--- |
|Fixed Tickets|#407|
|License      |MIT |
                    

Guard the remote branch exists in `pull-request:create`

* check if the remote branch exists
* ask to push when the remote branch doesn't exists but does local
* error when the remote branch doesn't exist and not local or not pushed

TODO:

* [x] Update test
* [x] Fix with partial-matching branch name "407-pull-" matches in "407-pull-create-warn-when-remote-branch-doesn-t-exist-and-ask-to-push" but does not exist itself.