### PR TITLE
Bugs pull request create

### DIFF
--- a/src/Command/PullRequest/PullRequestCreateCommand.php
+++ b/src/Command/PullRequest/PullRequestCreateCommand.php
@@ -175,7 +175,7 @@ EOF
         if (null === $issueNumber) {
             $defaultTitle = $input->getOption('title') ?: $this->getHelper('git')->getFirstCommitTitle($base, $sourceBranch);
 
-            if ('' === $defaultTitle && $input->isInteractive()) {
+            if ('' === $defaultTitle && !$input->isInteractive()) {
                 $styleHelper->error(
                     'Title can not be empty, use the "--title" option to provide a title in none-interactive mode.'
                 );
@@ -183,11 +183,13 @@ EOF
                 return self::COMMAND_FAILURE;
             }
 
-            $title = $styleHelper->ask('Title', $defaultTitle);
-            $body = $this->getHelper('template')->askAndRender(
-                $output,
-                $this->getTemplateDomain(),
-                $template
+            $title = trim($styleHelper->ask('Title', $defaultTitle));
+            $body = trim(
+                $this->getHelper('template')->askAndRender(
+                    $output,
+                    $this->getTemplateDomain(),
+                    $template
+                )
             );
         } elseif ($input->isInteractive() &&
             $styleHelper->confirm(sprintf('Replace issue #%d with a pull-request?', $issueNumber), true)

--- a/src/Template/PullRequest/Create/DefaultTemplate.php
+++ b/src/Template/PullRequest/Create/DefaultTemplate.php
@@ -17,9 +17,7 @@ class DefaultTemplate extends AbstractTemplate
 {
     public function render()
     {
-        $out = [];
-
-        return implode(PHP_EOL, $out);
+        return $this->parameters['description'];
     }
 
     /**
@@ -27,7 +25,9 @@ class DefaultTemplate extends AbstractTemplate
      */
     public function getRequirements()
     {
-        return [];
+        return [
+            'description' => ['Description', ''],
+        ];
     }
 
     public function getName()

--- a/tests/Command/PullRequest/PullRequestCreateCommandTest.php
+++ b/tests/Command/PullRequest/PullRequestCreateCommandTest.php
@@ -51,6 +51,7 @@ Open request on gushphp/gush
 // The source branch is "issue-145" on "cordoval".
 
 
+
 [OK] Opened pull request $url
 RES;
 
@@ -162,6 +163,7 @@ Open request on gushphp/gush
 // The source branch is "not-my-branch" on "gushphp".
 
 [OK] Branch "not-my-branch" was pushed to "gushphp".
+
 
 
 [OK] Opened pull request $url


### PR DESCRIPTION
While working on big refactoring I found to bugs that should be fixed now.

- The default template for pull-request:create did not ask for a description.
- When no title is provided and no title can be found in the using the first commit an exception was thrown, this should only happen when the command is executed in none-interactive mode.