### PR TITLE
Add BranchMergeCommand for remote merging branches (with a few extra's)

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -338,6 +338,7 @@ LOGO;
             new Cmd\Issue\IssueListCommand(),
             new Cmd\Issue\LabelIssuesCommand(),
             new Cmd\Branch\BranchPushCommand(),
+            new Cmd\Branch\BranchMergeCommand(),
             new Cmd\Branch\BranchSyncCommand(),
             new Cmd\Branch\BranchDeleteCommand(),
             new Cmd\Branch\BranchForkCommand(),

--- a/src/Command/Branch/BranchMergeCommand.php
+++ b/src/Command/Branch/BranchMergeCommand.php
@@ -1,0 +1,299 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2015 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Command\Branch;
+
+use Gush\Command\BaseCommand;
+use Gush\Config;
+use Gush\Exception\CannotSquashMultipleAuthors;
+use Gush\Feature\GitRepoFeature;
+use Gush\Helper\GitConfigHelper;
+use Gush\Helper\GitHelper;
+use Gush\Validator\MergeWorkflowValidator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BranchMergeCommand extends BaseCommand implements GitRepoFeature
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('branch:merge')
+            ->setDescription('Merges the remote branch into the given branch')
+            ->addArgument('source_branch', InputArgument::REQUIRED, 'Source branch to merge from')
+            ->addArgument('target_branch', InputArgument::REQUIRED, 'Target branch to merge to')
+            ->addOption(
+                'message',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Optional message to use for the merge commit, default is: Merge branch \'{{source}}\' into {{target}}'
+            )
+            ->addOption(
+                'no-log',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not append a commit summary log'
+            )
+            ->addOption(
+                'fast-forward',
+                'ff',
+                InputOption::VALUE_NONE,
+                'Merge branch using fast forward (no merge commit will be created)'
+            )
+            ->addOption(
+                'squash',
+                null,
+                InputOption::VALUE_NONE,
+                'Squash the commits before merging'
+            )
+            ->addOption(
+                'force-squash',
+                null,
+                InputOption::VALUE_NONE,
+                'Force squashing the commits, even if there are multiple authors (this will implicitly use --squash)'
+            )
+            ->addOption(
+                'ignore-workflow',
+                null,
+                InputOption::VALUE_NONE,
+                'Ignore merge workflow configuration'
+            )
+            ->addOption(
+                'source-org',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Source Organization - source organization name (defaults to current organization)'
+            )
+            ->addOption(
+                'source-repo',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Source Repository - source Repository name (defaults to current repository)'
+            )
+            ->setHelp(
+                <<<EOF
+The <info>%command.name%</info> command merges the given source branch into the target branch:
+
+    <info>$ gush %command.name% 2.3 2.7</info>
+
+The default merge message is <comment>Merge branch '{{ source }}' into {{ target }}\\n{{ commits_summary }}</>
+
+But you can change this by using the <comment>--message</> option:
+
+    <info>$ gush %command.name% 2.3 2.7 --message="Merge upstream changes into master"</info>
+
+The message is appended with a commits summary, to disable this use the <comment>--no-log</> option.
+
+    <info>$ gush %command.name% 2.3 2.7 --no-log --message="Merge upstream changes into master"</info>
+
+Squashing commits
+-----------------
+
+If there are many unrelated commits (like cs fixes) you can squash all the commits of the source branch
+into one big commit using:
+
+    <info>$ gush %command.name% --squash 2.3 2.7</info>
+
+This will use the message-body and author of the first commit in the source branch.
+
+<comment>Note:</> Squashing the sources branch requires that all the commits in the source branch
+were done by one author. You can overwrite this behaviour with <comment>--force-squash</>
+
+Merge workflow
+--------------
+
+Note: The merge workflow it only applied for merges performed with the %command.name%,
+pull-requests and using Git directly doesn't use the configured workflow.
+
+To prevent merging a newer version into an older one, the %command.name% always
+checks if the merge is correct according to your (teams) workflow.
+
+The default workflow checks if the source branch and target branch are
+versions, then checks if the source branch is lower then the target branch (merging
+bug fixes into a new version). And allows to merge "develop" into "master" (but not the
+other way around).
+
+If you have a more complex workflow you can configure this in your local
+<comment>.gush.yml</comment> file.
+
+Gush already supports a number of standard workflows, but creating your own is also possible.
+
+The merge_workflow.validation configuration is build is follow:
+
+  * "preset": use a standardized workflow, e.g: "git-flow", "semver" or "none".
+  * "branches": set a more specific validation (on top of the preset), each entry is a
+    key (source branch) and the value an array of allowed target branches.
+  * "unknown_branch_policy": what must be done when no rule matches, e.g: allow-merge, deny-merge.
+
+<warning>To prevent casting the branch name to a normalized number, always use quotes for a numeric
+branch name like '2.0'.</warning>
+
+Note that "branches" are validated after "preset", to only use "branches" set "none" as the "preset" value.
+
+Default workflow (allows to merge an older version into a newer one, but not the other way around,
+and allows any other merge):
+<comment>
+merge_workflow:
+    validation:
+        preset: semver
+        branches: []
+</comment>
+
+GitFlow as described in http://nvie.com/posts/a-successful-git-branching-model/:
+<comment>
+merge_workflow:
+    validation:
+        preset: git-flow
+</comment>
+
+Semantic version (allows to merge an older version into a newer once, but not the other way around):
+<comment>
+merge_workflow:
+    validation:
+        preset: semver
+</comment>
+
+Fully custom workflow validation:
+<comment>
+merge_workflow:
+    validation:
+        preset: none
+        unknown_branch_policy: allow-merge
+        branches:
+            develop: [master]
+            stable: [develop]
+            '2.3': ['2.4']
+            '2.4': ['2.5']
+            '2.5': ['master']
+</comment>
+
+If you want to skip the workflow for the current merge use the <comment>--ignore-workflow</> option.
+
+    <info>$ gush %command.name% --ignore-workflow 2.7 2.3</info>
+
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var GitHelper $gitHelper */
+        $gitHelper = $this->getHelper('git');
+        /** @var GitConfigHelper $gitConfigHelper */
+        $gitConfigHelper = $this->getHelper('git_config');
+
+        $targetOrg = $input->getOption('org');
+        $targetRepo = $input->getOption('repo');
+
+        $sourceOrg = $input->getOption('source-org');
+        $sourceRepo = $input->getOption('source-repo');
+
+        if (null === $sourceOrg) {
+            $sourceOrg = $targetOrg;
+        }
+
+        if (null === $sourceRepo) {
+            $sourceRepo = $targetRepo;
+        }
+
+        $gitConfigHelper->ensureRemoteExists($sourceOrg, $sourceRepo);
+        $gitConfigHelper->ensureRemoteExists($targetOrg, $targetRepo);
+
+        $squash = $input->getOption('squash') || $input->getOption('force-squash');
+
+        $targetBranch = $input->getArgument('target_branch');
+        $sourceBranch = $input->getArgument('source_branch');
+
+        if ($input->getOption('fast-forward')) {
+            $this->getHelper('gush_style')->note('Merging with fast-forward, merge message is not available.');
+        }
+
+        $this->validateWorkFlow($input, $sourceBranch, $targetBranch);
+
+        $message = (string) $input->getOption('message');
+
+        if ('' === $message) {
+            $message = sprintf(
+                "Merge branch '%s' into %s",
+                ($sourceOrg !== $targetOrg ? $sourceOrg.'/' : '').$sourceBranch,
+                $targetBranch
+            );
+        }
+
+        try {
+            $mergeOperation = $gitHelper->createRemoteMergeOperation();
+            $mergeOperation->setSource($sourceOrg, $sourceBranch);
+            $mergeOperation->setTarget($targetOrg, $targetBranch);
+            $mergeOperation->squashCommits($squash, $input->getOption('force-squash'));
+            $mergeOperation->setMergeMessage($message, !$input->getOption('no-log'));
+            $mergeOperation->useFastForward($input->getOption('fast-forward'));
+
+            $mergeOperation->performMerge();
+            $mergeOperation->pushToRemote();
+
+            $this->getHelper('gush_style')->success(
+                sprintf(
+                    'Branch "%s" has been merged into "%s".',
+                    $sourceOrg.'/'.$sourceBranch,
+                    $targetOrg.'/'.$targetBranch
+                )
+            );
+
+            return self::COMMAND_SUCCESS;
+        } catch (CannotSquashMultipleAuthors $e) {
+            $this->getHelper('gush_style')->error(
+                [
+                    "Enable to squash commits when there are multiple authors.",
+                    "Use --force-squash to continue or ask the author to squash commits manually."
+                ]
+            );
+
+            $gitHelper->restoreStashedBranch();
+
+            return self::COMMAND_FAILURE;
+        }
+    }
+
+    private function validateWorkFlow(InputInterface $input, $source, $target)
+    {
+        if ($input->getOption('ignore-workflow')) {
+            $this->getHelper('gush_style')->note('Ignoring merge-workflow.');
+
+            return;
+        }
+
+        $config = array_merge(
+            [
+                'preset' => 'semver',
+                'branches' => [],
+                'unknown_branch_policy' => MergeWorkflowValidator::BRANCH_POLICY_ALLOW
+            ],
+            $this->getConfig()->get(['merge_workflow', 'validation'], Config::CONFIG_LOCAL, [])
+        );
+
+        $validator = new MergeWorkflowValidator(
+            $config['preset'],
+            $config['branches'],
+            $config['unknown_branch_policy']
+        );
+
+        $validator->validate($source, $target);
+    }
+}

--- a/src/Exception/MergeWorkflowException.php
+++ b/src/Exception/MergeWorkflowException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2015 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Exception;
+
+final class MergeWorkflowException extends UserException
+{
+}

--- a/src/Operation/RemoteMergeOperation.php
+++ b/src/Operation/RemoteMergeOperation.php
@@ -30,6 +30,7 @@ class RemoteMergeOperation
     private $message;
     private $performed = false;
     private $fastForward = false;
+    private $withLog = false;
 
     public function __construct(GitHelper $gitHelper, FilesystemHelper $filesystemHelper)
     {
@@ -68,9 +69,10 @@ class RemoteMergeOperation
         return $this;
     }
 
-    public function setMergeMessage($message)
+    public function setMergeMessage($message, $withLog = false)
     {
         $this->message = $message;
+        $this->withLog = $withLog;
 
         return $this;
     }
@@ -105,12 +107,22 @@ class RemoteMergeOperation
         $this->createBaseBranch();
 
         $tempSourceBranch = $this->createSourceBranch();
-        $mergeHash = $this->gitHelper->mergeBranch(
-            $this->targetBase,
-            $tempSourceBranch,
-            $this->message,
-            $this->fastForward
-        );
+
+        if ($this->withLog) {
+            $mergeHash = $this->gitHelper->mergeBranchWithLog(
+                $this->targetBase,
+                $tempSourceBranch,
+                $this->message,
+                $this->sourceBranch
+            );
+        } else {
+            $mergeHash = $this->gitHelper->mergeBranch(
+                $this->targetBase,
+                $tempSourceBranch,
+                $this->message,
+                $this->fastForward
+            );
+        }
 
         $this->gitHelper->restoreStashedBranch();
 

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -11,6 +11,11 @@
 
 namespace Gush\Util;
 
+/**
+ * String utilities class.
+ *
+ * Some methods in this class are borrowed from the Doctrine project.
+ */
 final class StringUtil
 {
     public static function splitLines($input)
@@ -18,5 +23,33 @@ final class StringUtil
         $input = trim($input);
 
         return ((string) $input === '') ? [] : preg_split('{\r?\n}', $input);
+    }
+
+    /**
+     * Concatenates the words to an uppercased wording.
+     *
+     * Converts 'git-flow' to 'GitFlow'.
+     *
+     * @param string $word The word to transform.
+     *
+     * @return string The transformed word.
+     */
+    public static function concatWords($word)
+    {
+        return str_replace(" ", "", ucwords(strtr($word, "_-", "  ")));
+    }
+
+    /**
+     * Camelizes a word.
+     *
+     * This uses the classify() method and turns the first character to lowercase.
+     *
+     * @param string $word The word to camelize.
+     *
+     * @return string The camelized word.
+     */
+    public static function camelize($word)
+    {
+        return lcfirst(self::concatWords($word));
     }
 }

--- a/src/Validator/MergeWorkflowValidator.php
+++ b/src/Validator/MergeWorkflowValidator.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2015 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Validator;
+
+use Gush\Exception\MergeWorkflowException;
+use Gush\Exception\UserException;
+use Gush\Util\StringUtil;
+
+final class MergeWorkflowValidator
+{
+    const PRESET_SEMVER = 'semver';
+    const PRESET_GIT_FLOW = 'git-flow';
+    const PRESET_NONE = 'none';
+
+    const BRANCH_POLICY_ALLOW = 'allow-merge';
+    const BRANCH_POLICY_DENY = 'deny-merge';
+
+    /**
+     * The regular expression for a valid version number.
+     *
+     * Eg: 1.0, 1.x but not x.x
+     */
+    const VERSION_REGEX = '/^(?P<major>0|[1-9]\d*)\.(?P<minor>x|0|[1-9]\d*)$/';
+
+    /**
+     * @var string
+     */
+    private $preset;
+
+    /**
+     * @var string[]
+     */
+    private $branches;
+
+    /**
+     * @var string
+     */
+    private $policy;
+
+    /**
+     * Constructor.
+     *
+     * @param string   $preset
+     * @param string[] $branches
+     * @param string   $unknownBranchPolicy
+     *
+     * @throws UserException
+     */
+    public function __construct($preset, array $branches = [], $unknownBranchPolicy = self::BRANCH_POLICY_ALLOW)
+    {
+        if (!in_array($preset, [self::PRESET_SEMVER, self::PRESET_GIT_FLOW, self::PRESET_NONE], true)) {
+            throw new \InvalidArgumentException(
+                [
+                    'Merge workflow preset is not valid.',
+                    'Supported workflow presets are: semver, git-flow or none.'
+                ]
+            );
+        }
+
+        if (!in_array($unknownBranchPolicy, [self::BRANCH_POLICY_ALLOW, self::BRANCH_POLICY_DENY], true)) {
+            throw new \InvalidArgumentException(
+                [
+                    'Merge workflow-policy is not valid.',
+                    'Supported workflow policies are: allow-merge or deny-merge.'
+                ]
+            );
+        }
+
+        if (self::BRANCH_POLICY_DENY === $unknownBranchPolicy && 0 === count($branches)) {
+            throw new \InvalidArgumentException(
+                'Merge workflow-policy is set to "deny-merge" but no branches are configured.'
+            );
+        }
+
+        $this->preset = $preset;
+        $this->branches = $branches;
+        $this->policy = $unknownBranchPolicy;
+    }
+
+    public function validate($source, $target)
+    {
+        $validateBranches = count($this->branches) > 1;
+
+        if (self::PRESET_NONE !== $this->preset) {
+            $preset = 'preset'.StringUtil::concatWords($this->preset);
+
+            // When the policy is deny-merge for unknown branches
+            // the preset is used as primary, if it grants access then branches are not checked,
+            // else you would need configure branches for all checks!
+            if (true === $this->$preset($source, $target)) {
+                $validateBranches = self::BRANCH_POLICY_DENY === $this->policy ? false : $validateBranches;
+            }
+        }
+
+        if ($validateBranches) {
+            $this->validateBranches($source, $target, $this->branches, $this->policy);
+        }
+
+        return true;
+    }
+
+    protected function presetSemver($source, $target)
+    {
+        if (0 === preg_match(self::VERSION_REGEX, $source, $sourceMatch) ||
+            0 === preg_match(self::VERSION_REGEX, $target, $targetMatch)
+        ) {
+            return; // cannot validate branches, abstain decision
+        }
+
+        if ((int) $sourceMatch['major'] > (int) $targetMatch['major']) {
+            throw new MergeWorkflowException(
+                [
+                    sprintf('Workflow violation: Cannot merge "%s" into "%s".', $source, $target),
+                    sprintf(
+                        'Semver: major version of source "%s" is higher then major version of target "%s".',
+                        $source,
+                        $target
+                    )
+                ]
+            );
+        }
+
+        if ('x' === $sourceMatch['minor'] || 'x' === $targetMatch['minor']) {
+            return true; // allow merge
+        }
+
+        if ((int) $sourceMatch['minor'] > (int) $targetMatch['minor']) {
+            throw new MergeWorkflowException(
+                [
+                    sprintf('Workflow violation: Cannot merge "%s" into "%s".', $source, $target),
+                    sprintf(
+                        'Semver: minor version of source "%s" is higher then minor version of target "%s".',
+                        $source,
+                        $target
+                    )
+                ]
+            );
+        }
+    }
+
+    protected function presetGitFlow($source, $target)
+    {
+        if ($target !== 'master') {
+            return; // abstain decision
+        }
+
+        // Source can be master (from another org/repo)
+        if ($source === 'master' || $source === 'develop' || preg_match('/^(hotfix|release)-/', $source)) {
+            return true; // allow to merge into master
+        }
+
+        throw new MergeWorkflowException(
+            [
+                sprintf('Workflow violation: Cannot merge "%s" into "%s".', $source, $target),
+                'Git-flow: Only "develop", "hotfix-" or "release-" branches are allowed to be merged into master.'
+            ]
+        );
+    }
+
+    private function validateBranches($source, $target, array $branches, $policy)
+    {
+        if (array_key_exists($source, $branches)) {
+            $acceptedBranch = (array) $branches[$source];
+
+            if (!in_array($target, $acceptedBranch, true)) {
+                throw new MergeWorkflowException(
+                    [
+                        sprintf('Workflow violation: Cannot merge "%s" into "%s".', $source, $target),
+                        sprintf(
+                            'Branches: Only branches "%s" are allowed to be merged into "%s".',
+                            implode('", "', $acceptedBranch),
+                            $target
+                        ),
+                    ]
+                );
+            }
+
+            return; // allow merge
+        }
+
+        if (self::BRANCH_POLICY_DENY === $policy) {
+            throw new MergeWorkflowException(
+                [
+                    sprintf('Workflow violation: Cannot merge "%s" into "%s".', $source, $target),
+                    sprintf(
+                        'No branch constraint is set for source "%s" and policy denies merging unknown branches.',
+                        $source
+                    ),
+                ]
+            );
+        }
+    }
+}

--- a/tests/Command/Branch/BranchMergeCommandTest.php
+++ b/tests/Command/Branch/BranchMergeCommandTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2015 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Tests\Command\Branch;
+
+use Gush\Command\Branch\BranchMergeCommand;
+use Gush\Operation\RemoteMergeOperation;
+use Gush\Tests\Command\CommandTestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Helper\HelperSet;
+
+class BranchMergeCommandTest extends CommandTestCase
+{
+    const MERGE_HASH = '8ae59958a2632018275b8db9590e9a79331030cb';
+
+    const COMMAND_DISPLAY = 'Branch "%s" has been merged into "%s"';
+
+    private $mergeMessage = "Merge branch '%s' into %s";
+
+    public function testMergeBranchWithDefaultWorkFlow()
+    {
+        $command = new BranchMergeCommand();
+        $tester = $this->getCommandTester(
+            $command,
+            null,
+            null,
+            function (HelperSet $helperSet) {
+                $helperSet->set($this->getLocalGitHelper(sprintf($this->mergeMessage, 'develop', 'master'))->reveal());
+            }
+        );
+
+        $tester->execute(
+            ['target_branch' => 'master', 'source_branch' => 'develop'],
+            ['interactive' => false]
+        );
+
+        $display = $tester->getDisplay();
+        $this->assertCommandOutputMatches(
+            sprintf(self::COMMAND_DISPLAY, 'gushphp/develop', 'gushphp/master'),
+            $display
+        );
+    }
+
+    public function testMergeBranchWithConfiguredWorkflow()
+    {
+        $command = new BranchMergeCommand();
+        $tester = $this->getCommandTester(
+            $command,
+            null,
+            array_merge(
+                self::$localConfig,
+                [
+                    'merge_workflow' => ['validation' => ['preset' => 'git-flow']]
+                ]
+            ),
+            function (HelperSet $helperSet) {
+                $helperSet->set($this->getLocalGitHelper(sprintf($this->mergeMessage, 'develop', 'master'))->reveal());
+            }
+        );
+
+        $tester->execute(
+            ['target_branch' => 'master', 'source_branch' => 'develop'],
+            ['interactive' => false]
+        );
+
+        $display = $tester->getDisplay();
+        $this->assertCommandOutputMatches(
+            sprintf(self::COMMAND_DISPLAY, 'gushphp/develop', 'gushphp/master'),
+            $display
+        );
+    }
+
+    public function testMergeBranchWithCustomMessage()
+    {
+        $command = new BranchMergeCommand();
+        $tester = $this->getCommandTester(
+            $command,
+            null,
+            null,
+            function (HelperSet $helperSet) {
+                $helperSet->set($this->getLocalGitHelper('Merge upstream changes into master')->reveal());
+            }
+        );
+
+        $tester->execute(
+            [
+                'target_branch' => 'master',
+                'source_branch' => 'develop',
+                '--message' => 'Merge upstream changes into master',
+            ],
+            ['interactive' => false]
+        );
+
+        $display = $tester->getDisplay();
+        $this->assertCommandOutputMatches(
+            sprintf(self::COMMAND_DISPLAY, 'gushphp/develop', 'gushphp/master'),
+            $display
+        );
+    }
+
+    public function testMergePullRequestWithSquashOption()
+    {
+        $command = new BranchMergeCommand();
+        $tester = $this->getCommandTester(
+            $command,
+            null,
+            null,
+            function (HelperSet $helperSet) {
+                $helperSet->set(
+                    $this->getLocalGitHelper(sprintf($this->mergeMessage, 'develop', 'master'), true)->reveal()
+                );
+            }
+        );
+
+        $tester->execute(
+            ['target_branch' => 'master', 'source_branch' => 'develop', '--squash' => true],
+            ['interactive' => false]
+        );
+
+        $display = $tester->getDisplay();
+        $this->assertCommandOutputMatches(
+            sprintf(self::COMMAND_DISPLAY, 'gushphp/develop', 'gushphp/master'),
+            $display
+        );
+    }
+
+    public function testMergePullRequestWithForceSquashOption()
+    {
+        $command = new BranchMergeCommand();
+        $tester = $this->getCommandTester(
+            $command,
+            null,
+            null,
+            function (HelperSet $helperSet) {
+                $helperSet->set(
+                    $this->getLocalGitHelper(sprintf($this->mergeMessage, 'develop', 'master'), true, true)->reveal()
+                );
+            }
+        );
+
+        $tester->execute(
+            ['target_branch' => 'master', 'source_branch' => 'develop', '--force-squash' => true],
+            ['interactive' => false]
+        );
+
+        $display = $tester->getDisplay();
+        $this->assertCommandOutputMatches(
+            sprintf(self::COMMAND_DISPLAY, 'gushphp/develop', 'gushphp/master'),
+            $display
+        );
+    }
+
+    public function testMergePullRequestWithFastForward()
+    {
+        $command = new BranchMergeCommand();
+        $tester = $this->getCommandTester(
+            $command,
+            null,
+            null,
+            function (HelperSet $helperSet) {
+                $helperSet->set(
+                    $this->getLocalGitHelper(
+                        sprintf($this->mergeMessage, 'develop', 'master'),
+                        false,
+                        false,
+                        true
+                    )->reveal()
+                );
+            }
+        );
+
+        $tester->execute(
+            ['target_branch' => 'master', 'source_branch' => 'develop', '--fast-forward' => true],
+            ['interactive' => false]
+        );
+
+        $display = $tester->getDisplay();
+        $this->assertCommandOutputMatches(
+            sprintf(self::COMMAND_DISPLAY, 'gushphp/develop', 'gushphp/master'),
+            $display
+        );
+    }
+
+    protected function getGitConfigHelper()
+    {
+        $helper = parent::getGitConfigHelper();
+
+        $helper->ensureRemoteExists('gushphp', 'gush')->shouldBeCalled();
+
+        return $helper;
+    }
+
+    private function getLocalGitHelper($message = null, $squash = false, $forceSquash = false, $fastForward = false)
+    {
+        $helper = parent::getGitHelper();
+
+        $mergeOperation = $this->prophesize(RemoteMergeOperation::class);
+        $mergeOperation->setTarget('gushphp', 'master')->shouldBeCalled();
+        $mergeOperation->setSource('gushphp', 'develop')->shouldBeCalled();
+        $mergeOperation->squashCommits($squash, $forceSquash)->shouldBeCalled();
+        $mergeOperation->useFastForward($fastForward)->shouldBeCalled();
+        $mergeOperation->setMergeMessage($message, true)->shouldBeCalled();
+
+        $mergeOperation->performMerge()->willReturn(self::MERGE_HASH);
+        $mergeOperation->pushToRemote()->shouldBeCalled();
+
+        $helper->createRemoteMergeOperation()->willReturn($mergeOperation->reveal());
+
+        return $helper;
+    }
+}

--- a/tests/Helper/GitHelperTest.php
+++ b/tests/Helper/GitHelperTest.php
@@ -138,7 +138,7 @@ class GitHelperTest extends \PHPUnit_Framework_TestCase
         $processHelper->runCommands(
             [
                 [
-                    'line' => ['git', 'merge', '--no-ff', '--no-commit', 'amazing-feature'],
+                    'line' => ['git', 'merge', '--no-ff', '--no-commit', '--no-log', 'amazing-feature'],
                     'allow_failures' => false,
                 ],
                 [

--- a/tests/Validator/MergeWorkflowValidatorTest.php
+++ b/tests/Validator/MergeWorkflowValidatorTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Gush\Tests\Validator;
+
+use Gush\Exception\MergeWorkflowException;
+use Gush\Validator\MergeWorkflowValidator;
+
+final class MergeWorkflowValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideValidSemverBranches
+     *
+     * @param string $source
+     * @param string $target
+     */
+    public function testValidSemverPresetWithNoBranches($source, $target)
+    {
+        $validator = new MergeWorkflowValidator(MergeWorkflowValidator::PRESET_SEMVER);
+
+        $this->assertTrue($validator->validate($source, $target));
+    }
+
+    public function provideValidSemverBranches()
+    {
+        return [
+            ['1.0', '2.0'],
+            ['1.0', '1.1'],
+            ['1.0', '2.x'],
+            ['1.x', '2.x'],
+            ['1.x', '2.5'],
+            ['1.5', '2.x'],
+            ['x.5', 'x.0'], // version is invalid, so its ignored
+            ['develop', 'master'], // version is invalid, so its ignored
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidSemverBranches
+     *
+     * @param string $source
+     * @param string $target
+     * @param string $invalidPart
+     */
+    public function testInvalidSemverPresetWithNoBranches($source, $target, $invalidPart)
+    {
+        $validator = new MergeWorkflowValidator(MergeWorkflowValidator::PRESET_SEMVER);
+
+        $this->setExpectedException(
+            MergeWorkflowException::class,
+            sprintf(
+                'Semver: %1$s version of source "%2$s" is higher then %1$s version of target "%3$s".',
+                $invalidPart,
+                $source,
+                $target
+            )
+        );
+
+        $validator->validate($source, $target);
+    }
+
+    public function provideInvalidSemverBranches()
+    {
+        return [
+            ['2.0', '1.0', 'major'],
+            ['2.x', '1.x', 'major'],
+            ['2.5', '2.0', 'minor'],
+            ['1.8', '1.5', 'minor'],
+        ];
+    }
+
+    // GitFlow
+
+    /**
+     * @dataProvider provideValidGitFlowBranches
+     *
+     * @param string $source
+     * @param string $target
+     */
+    public function testValidGitFlowPresetWithNoBranches($source, $target)
+    {
+        $validator = new MergeWorkflowValidator(MergeWorkflowValidator::PRESET_GIT_FLOW);
+
+        $this->assertTrue($validator->validate($source, $target));
+    }
+
+    public function provideValidGitFlowBranches()
+    {
+        return [
+            ['develop', 'master'],
+            ['master', 'develop'],
+            ['master', 'master'],
+            ['hotfix-255', 'master'],
+            ['release-255', 'master'],
+            ['hotfix-255', 'develop'],
+            ['release-255', 'develop'],
+            ['my-feature', 'develop'],
+            // Semver branches, ignored
+            ['1.0', '2.0'],
+            ['1.x', '2.x'],
+            ['2.8', '2.5'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidGitFlowBranches
+     *
+     * @param string $source
+     */
+    public function testInvalidGitFlowPresetWithNoBranches($source)
+    {
+        $validator = new MergeWorkflowValidator(MergeWorkflowValidator::PRESET_GIT_FLOW);
+
+        $this->setExpectedException(
+            MergeWorkflowException::class,
+            'Git-flow: Only "develop", "hotfix-" or "release-" branches are allowed to be merged into master.'
+        );
+
+        $validator->validate($source, 'master');
+    }
+
+    public function provideInvalidGitFlowBranches()
+    {
+        return [
+            ['my-feature'],
+            ['2.5'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideAllowedBranches
+     *
+     * @param string $source
+     * @param string $target
+     */
+    public function testBranchRestrictionsWithAllowUnknown($source, $target)
+    {
+        $validator = new MergeWorkflowValidator(
+            MergeWorkflowValidator::PRESET_NONE,
+            [
+                'master' => ['master', 'develop'],
+                'develop' => ['develop', 'new-feature'],
+            ]
+        );
+
+        $this->assertTrue($validator->validate($source, $target));
+    }
+
+    public function provideAllowedBranches()
+    {
+        return [
+            ['master', 'develop'],
+            ['master', 'master'],
+            ['develop', 'new-feature'],
+            ['2.5', '2.8'], // not mentioned, so allowed
+        ];
+    }
+
+    /**
+     * @dataProvider provideDeniedBranches
+     *
+     * @param string $source
+     * @param string $target
+     */
+    public function testBranchRestrictionsWithDeniedBranchAndAllowUnknown($source, $target)
+    {
+        $restrictions = [
+            'master' => ['master', 'develop'],
+            'develop' => ['develop', 'new-feature'],
+        ];
+
+        $validator = new MergeWorkflowValidator(MergeWorkflowValidator::PRESET_NONE, $restrictions);
+
+        $this->setExpectedException(
+            MergeWorkflowException::class,
+            sprintf(
+                'Branches: Only branches "%s" are allowed to be merged into "%s".',
+                implode('", "', $restrictions[$source]),
+                $target
+            )
+        );
+
+        $validator->validate($source, $target);
+    }
+
+    public function provideDeniedBranches()
+    {
+        return [
+            ['develop', 'master'],
+            ['master', 'new-feature'],
+        ];
+    }
+
+     public function testBranchRestrictionsDeniesAccessForUnknownBranchWithPolicyDeny()
+    {
+        $restrictions = [
+            'master' => ['master', 'develop'],
+            'develop' => ['develop', 'new-feature'],
+        ];
+
+        $validator = new MergeWorkflowValidator(
+            MergeWorkflowValidator::PRESET_NONE,
+            $restrictions,
+            MergeWorkflowValidator::BRANCH_POLICY_DENY
+        );
+
+        $this->assertTrue($validator->validate('master', 'master'));
+        $this->assertTrue($validator->validate('master', 'develop'));
+        $this->assertTrue($validator->validate('develop', 'new-feature'));
+
+        $this->setExpectedException(
+            MergeWorkflowException::class,
+            'No branch constraint is set for source "new-feature" and policy denies merging unknown branches.'
+        );
+
+        $validator->validate('new-feature', 'develop');
+    }
+}


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Fixed Tickets|   |
|License      |MIT|
                   

This command does more the just merging, it also guards that the branches are merged according to
a configured workflow (eg no 2.3 to > 2.0).

The workflow is completely adjustable to ones needs, at the moment it supports semver and Git-flow.
And allows to configure constraints to which branches maybe to where.

Todo:

- [x] Testing
- [x] Fix missing commits-notes `--notes` when merging (GitHelper)