### PR TITLE
Remove new-line at end of header dockblock

### DIFF
--- a/src/Helper/MetaHelper.php
+++ b/src/Helper/MetaHelper.php
@@ -72,7 +72,6 @@ class MetaHelper extends Helper
             $out[] = $prefix.' '.$class->getDelimiter().($line ? ' '.$line : '');
         }
         $out[] = $prefix.' '.$class->getEndDelimiter();
-        $out[] = $prefix."\n";
 
         return implode("\n", $out);
     }


### PR DESCRIPTION
php-cs-fixer removes all new lines after the header dockblock, so it shouldn't be there