### PR TITLE
Introduce baseAdapter capability, add support for multiple adapter configurations

### DIFF
--- a/src/Adapter/Configurator.php
+++ b/src/Adapter/Configurator.php
@@ -41,7 +41,7 @@ interface Configurator
     /**
      * Get the unique name for a configured adapter.
      *
-     * @return mixed
+     * @return string
      */
     public function getConfigurationIdentifier($adapter, $config);
 }

--- a/src/Adapter/Configurator.php
+++ b/src/Adapter/Configurator.php
@@ -39,23 +39,9 @@ interface Configurator
     public function interact(InputInterface $input, OutputInterface $output);
 
     /**
-     * Get the base adapter name.
-     *
-     * @return string
-     */
-    public function getBaseAdapterName();
-
-    /**
-     * Set the base adapter name.
-     *
-     * @return string
-     */
-    public function setBaseAdapterName($name);
-
-    /**
      * Get the unique name for a configured adapter.
      *
      * @return mixed
      */
-    public function getAdapterName($config);
+    public function getConfigurationIdentifier($adapter, $config);
 }

--- a/src/Adapter/Configurator.php
+++ b/src/Adapter/Configurator.php
@@ -37,4 +37,25 @@ interface Configurator
      * @throws \Exception When any of the validators returns an error
      */
     public function interact(InputInterface $input, OutputInterface $output);
+
+    /**
+     * Get the base adapter name.
+     *
+     * @return string
+     */
+    public function getBaseAdapterName();
+
+    /**
+     * Set the base adapter name.
+     *
+     * @return string
+     */
+    public function setBaseAdapterName($name);
+
+    /**
+     * Get the unique name for a configured adapter.
+     *
+     * @return mixed
+     */
+    public function getAdapterName($config);
 }

--- a/src/Adapter/DefaultConfigurator.php
+++ b/src/Adapter/DefaultConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace Gush\Adapter;
 
+use Gush\Util\ConfigUtil;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,11 +47,6 @@ class DefaultConfigurator implements Configurator
      * @var string[]
      */
     protected $authenticationOptions = [];
-
-    /**
-     * @var string
-     */
-    protected $baseAdapterName;
 
     /**
      * Constructor.
@@ -192,32 +188,12 @@ class DefaultConfigurator implements Configurator
     }
 
     /**
-     * Get the base adapter name.
-     *
-     * @return string
-     */
-    public function getBaseAdapterName()
-    {
-        return $this->baseAdapterName;
-    }
-
-    /**
-     * Set the base adapter name.
-     *
-     * @return string
-     */
-    public function setBaseAdapterName($name)
-    {
-        $this->baseAdapterName = $name;
-    }
-
-    /**
      * Get the unique name of a configured adapter.
      *
      * @return string
      */
-    public function getAdapterName($config)
+    public function getConfigurationIdentifier($adapter, $config)
     {
-        $this->getBaseAdapterName();
+        return ConfigUtil::generateConfigurationIdentifier($adapter, $config);
     }
 }

--- a/src/Adapter/DefaultConfigurator.php
+++ b/src/Adapter/DefaultConfigurator.php
@@ -48,6 +48,11 @@ class DefaultConfigurator implements Configurator
     protected $authenticationOptions = [];
 
     /**
+     * @var string
+     */
+    protected $baseAdapterName;
+
+    /**
      * Constructor.
      *
      * @param QuestionHelper $questionHelper        QuestionHelper instance
@@ -184,5 +189,35 @@ class DefaultConfigurator implements Configurator
         }
 
         return $url;
+    }
+
+    /**
+     * Get the base adapter name.
+     *
+     * @return string
+     */
+    public function getBaseAdapterName()
+    {
+        return $this->baseAdapterName;
+    }
+
+    /**
+     * Set the base adapter name.
+     *
+     * @return string
+     */
+    public function setBaseAdapterName($name)
+    {
+        $this->baseAdapterName = $name;
+    }
+
+    /**
+     * Get the unique name of a configured adapter.
+     *
+     * @return string
+     */
+    public function getAdapterName($config)
+    {
+        $this->getBaseAdapterName();
     }
 }

--- a/src/Command/Core/CoreConfigureCommand.php
+++ b/src/Command/Core/CoreConfigureCommand.php
@@ -169,6 +169,7 @@ EOF
 
         if ($isAuthenticated) {
             $rawConfig = $this->getConfig()->toArray(Config::CONFIG_SYSTEM);
+            $adapterName = $configurator->getAdapterName($config);
             $rawConfig['adapters'][$adapterName] = $config;
 
             $styleHelper->success(sprintf('The "%s" adapter was successfully authenticated.', $adapter['label']));

--- a/src/Command/Core/CoreConfigureCommand.php
+++ b/src/Command/Core/CoreConfigureCommand.php
@@ -169,8 +169,8 @@ EOF
 
         if ($isAuthenticated) {
             $rawConfig = $this->getConfig()->toArray(Config::CONFIG_SYSTEM);
-            $adapterName = $configurator->getAdapterName($config);
-            $rawConfig['adapters'][$adapterName] = $config;
+            $identifier = $configurator->getConfigurationIdentifier($adapterName, $config);
+            $rawConfig['adapters'][$identifier] = $config;
 
             $styleHelper->success(sprintf('The "%s" adapter was successfully authenticated.', $adapter['label']));
 

--- a/src/Factory/AdapterFactory.php
+++ b/src/Factory/AdapterFactory.php
@@ -186,19 +186,17 @@ class AdapterFactory
      */
     private function getFactoryObject($name)
     {
-        $baseAdapter = $name;
-
-        if (!isset($this->adapters[$baseAdapter])) {
-            throw new \InvalidArgumentException(sprintf('No Adapter with name "%s" is registered.', $baseAdapter));
+        if (!isset($this->adapters[$name])) {
+            throw new \InvalidArgumentException(sprintf('No Adapter with name "%s" is registered.', $name));
         }
 
-        if (!is_object($this->adapters[$baseAdapter]['factory'])) {
-            $factory = $this->adapters[$baseAdapter]['factory'];
+        if (!is_object($this->adapters[$name]['factory'])) {
+            $factory = $this->adapters[$name]['factory'];
 
-            $this->adapters[$baseAdapter]['factory'] = new $factory();
+            $this->adapters[$name]['factory'] = new $factory();
         }
 
-        return $this->adapters[$baseAdapter]['factory'];
+        return $this->adapters[$name]['factory'];
     }
 
     private function guardFactoryClassImplementation($name, $label, $adapterFactory)

--- a/src/Factory/AdapterFactory.php
+++ b/src/Factory/AdapterFactory.php
@@ -41,7 +41,7 @@ class AdapterFactory
             throw new \InvalidArgumentException(sprintf('An adapter with name "%s" is already registered.', $name));
         }
 
-        $this->adapters[$name] = $this->guardFactoryClassImplementation($adapterFactory, $label);
+        $this->adapters[$name] = $this->guardFactoryClassImplementation($name, $label, $adapterFactory);
     }
 
     /**
@@ -118,8 +118,6 @@ class AdapterFactory
         }
 
         $adapter = $this->adapters[$name];
-        $adapter->setBaseAdapterName($name);
-
         return $adapter;
     }
 
@@ -191,7 +189,7 @@ class AdapterFactory
      */
     private function getFactoryObject($name)
     {
-        $baseAdapter = $this->getBaseAdapter($name);
+        $baseAdapter = $name;
 
         if (!isset($this->adapters[$baseAdapter])) {
             throw new \InvalidArgumentException(sprintf('No Adapter with name "%s" is registered.', $baseAdapter));
@@ -206,7 +204,7 @@ class AdapterFactory
         return $this->adapters[$baseAdapter]['factory'];
     }
 
-    private function guardFactoryClassImplementation($adapterFactory, $label)
+    private function guardFactoryClassImplementation($name, $label, $adapterFactory)
     {
         $adapterFactoryClass = is_object($adapterFactory) ? get_class($adapterFactory) : $adapterFactory;
         $classImplements = class_implements($adapterFactoryClass);
@@ -225,8 +223,9 @@ class AdapterFactory
         }
 
         return [
-            'factory' => $adapterFactory,
+            'name' => $name,
             'label' => $label,
+            'factory' => $adapterFactory,
             self::SUPPORT_REPOSITORY_MANAGER => $repositoryManager,
             self::SUPPORT_ISSUE_TRACKER => $issueTracker,
         ];

--- a/src/Factory/AdapterFactory.php
+++ b/src/Factory/AdapterFactory.php
@@ -67,11 +67,13 @@ class AdapterFactory
      */
     public function supports($name, $supports)
     {
-        if (!isset($this->adapters[$name])) {
+        $baseAdapter = $this->getBaseAdapter($name);
+
+        if (!isset($this->adapters[$baseAdapter])) {
             return false;
         }
 
-        return $this->adapters[$name][$supports];
+        return $this->adapters[$baseAdapter][$supports];
     }
 
     /**
@@ -115,7 +117,10 @@ class AdapterFactory
             throw new \InvalidArgumentException(sprintf('No Adapter with name "%s" is registered.', $name));
         }
 
-        return $this->adapters[$name];
+        $adapter = $this->adapters[$name];
+        $adapter->setBaseAdapterName($name);
+
+        return $adapter;
     }
 
     /**
@@ -186,17 +191,19 @@ class AdapterFactory
      */
     private function getFactoryObject($name)
     {
-        if (!isset($this->adapters[$name])) {
-            throw new \InvalidArgumentException(sprintf('No Adapter with name "%s" is registered.', $name));
+        $baseAdapter = $this->getBaseAdapter($name);
+
+        if (!isset($this->adapters[$baseAdapter])) {
+            throw new \InvalidArgumentException(sprintf('No Adapter with name "%s" is registered.', $baseAdapter));
         }
 
-        if (!is_object($this->adapters[$name]['factory'])) {
-            $factory = $this->adapters[$name]['factory'];
+        if (!is_object($this->adapters[$baseAdapter]['factory'])) {
+            $factory = $this->adapters[$baseAdapter]['factory'];
 
-            $this->adapters[$name]['factory'] = new $factory();
+            $this->adapters[$baseAdapter]['factory'] = new $factory();
         }
 
-        return $this->adapters[$name]['factory'];
+        return $this->adapters[$baseAdapter]['factory'];
     }
 
     private function guardFactoryClassImplementation($adapterFactory, $label)
@@ -224,4 +231,10 @@ class AdapterFactory
             self::SUPPORT_ISSUE_TRACKER => $issueTracker,
         ];
     }
+
+    private  function getBaseAdapter($name) {
+      $array = explode(':', $name);
+      return $array[0];
+    }
+
 }

--- a/src/Factory/AdapterFactory.php
+++ b/src/Factory/AdapterFactory.php
@@ -115,8 +115,7 @@ class AdapterFactory
             throw new \InvalidArgumentException(sprintf('No Adapter with name "%s" is registered.', $name));
         }
 
-        $adapter = $this->adapters[$name];
-        return $adapter;
+        return $this->adapters[$name];
     }
 
     /**

--- a/src/Factory/AdapterFactory.php
+++ b/src/Factory/AdapterFactory.php
@@ -67,13 +67,11 @@ class AdapterFactory
      */
     public function supports($name, $supports)
     {
-        $baseAdapter = $this->getBaseAdapter($name);
-
-        if (!isset($this->adapters[$baseAdapter])) {
+        if (!isset($this->adapters[$name])) {
             return false;
         }
 
-        return $this->adapters[$baseAdapter][$supports];
+        return $this->adapters[$name][$supports];
     }
 
     /**
@@ -229,11 +227,6 @@ class AdapterFactory
             self::SUPPORT_REPOSITORY_MANAGER => $repositoryManager,
             self::SUPPORT_ISSUE_TRACKER => $issueTracker,
         ];
-    }
-
-    private  function getBaseAdapter($name) {
-      $array = explode(':', $name);
-      return $array[0];
     }
 
 }

--- a/src/Factory/LegacyAdapterFactory.php
+++ b/src/Factory/LegacyAdapterFactory.php
@@ -77,4 +77,5 @@ final class LegacyAdapterFactory implements RepositoryManagerFactory, IssueTrack
     {
         return $this->className;
     }
+
 }

--- a/src/Factory/LegacyAdapterFactory.php
+++ b/src/Factory/LegacyAdapterFactory.php
@@ -77,5 +77,4 @@ final class LegacyAdapterFactory implements RepositoryManagerFactory, IssueTrack
     {
         return $this->className;
     }
-
 }

--- a/src/Subscriber/BaseGitRepoSubscriber.php
+++ b/src/Subscriber/BaseGitRepoSubscriber.php
@@ -54,9 +54,9 @@ abstract class BaseGitRepoSubscriber implements EventSubscriberInterface
      */
     protected function getAdapter($adapterName, $config)
     {
-        $hash = ConfigUtil::generateConfigurationIdentifier($adapterName, $config);
+        $identifier = ConfigUtil::generateConfigurationIdentifier($adapterName, $config);
 
-        $config = $this->application->getConfig()->get(['adapters', $hash], Config::CONFIG_SYSTEM);
+        $config = $this->application->getConfig()->get(['adapters', $identifier], Config::CONFIG_SYSTEM);
         $adapter = $this->application->getAdapterFactory()->createRepositoryManager(
             $adapterName,
             $config,

--- a/src/Subscriber/BaseGitRepoSubscriber.php
+++ b/src/Subscriber/BaseGitRepoSubscriber.php
@@ -18,6 +18,7 @@ use Gush\Exception\UserException;
 use Gush\Helper\GitConfigHelper;
 use Gush\Helper\GitHelper;
 use Gush\Helper\StyleHelper;
+use Gush\Util\ConfigUtil;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 abstract class BaseGitRepoSubscriber implements EventSubscriberInterface
@@ -51,9 +52,11 @@ abstract class BaseGitRepoSubscriber implements EventSubscriberInterface
      *
      * @throws UserException
      */
-    protected function getAdapter($adapterName)
+    protected function getAdapter($adapterName, $config)
     {
-        $config = $this->application->getConfig()->get(['adapters', $adapterName], Config::CONFIG_SYSTEM);
+        $hash = ConfigUtil::generateConfigurationIdentifier($adapterName, $config);
+
+        $config = $this->application->getConfig()->get(['adapters', $hash], Config::CONFIG_SYSTEM);
         $adapter = $this->application->getAdapterFactory()->createRepositoryManager(
             $adapterName,
             $config,

--- a/src/Subscriber/CoreInitSubscriber.php
+++ b/src/Subscriber/CoreInitSubscriber.php
@@ -147,7 +147,7 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
 
         if (null === $org || null === $repo) {
             list($org, $repo) = $this->getRepositoryReference(
-                $this->getAdapter($input->getOption('repo-adapter')),
+                $this->getAdapter($input->getOption('repo-adapter'), $input->getOption('repo-adapter-config')),
                 $org,
                 $repo
             );

--- a/src/Subscriber/GitRepoSubscriber.php
+++ b/src/Subscriber/GitRepoSubscriber.php
@@ -305,8 +305,8 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
         $input->setOption('issue-project', $issueRepo);
         $input->setOption('issue-adapter', $issueAdapterName);
 
-        $hash = ConfigUtil::generateConfigurationIdentifier($issueAdapterName, $input->getOption('issue-adapter-config'));
-        $config = $this->application->getConfig()->get(['adapters', $hash], Config::CONFIG_SYSTEM);
+        $identifier = ConfigUtil::generateConfigurationIdentifier($issueAdapterName, $input->getOption('issue-adapter-config'));
+        $config = $this->application->getConfig()->get(['adapters', $identifier], Config::CONFIG_SYSTEM);
 
         $issueTracker = $this->application->getAdapterFactory()->createIssueTracker(
             $issueAdapterName,

--- a/src/Subscriber/GitRepoSubscriber.php
+++ b/src/Subscriber/GitRepoSubscriber.php
@@ -127,7 +127,7 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
                 'iac',
                 InputOption::VALUE_REQUIRED,
                 'Config of the issue-tracker',
-                $this->application->getConfig()->get('issue_tracker_config', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ADAPTER)
+                $this->application->getConfig()->get('issue_adapter_config', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ADAPTER)
             )
             ->addOption(
                 'issue-org',

--- a/src/Subscriber/GitRepoSubscriber.php
+++ b/src/Subscriber/GitRepoSubscriber.php
@@ -19,6 +19,7 @@ use Gush\Factory\AdapterFactory;
 use Gush\Feature\GitRepoFeature;
 use Gush\Feature\IssueTrackerRepoFeature;
 use Gush\Helper\GitHelper;
+use Gush\Util\ConfigUtil;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -52,6 +53,16 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
                     $this->getSupportedAdapters(AdapterFactory::SUPPORT_REPOSITORY_MANAGER)
                 ),
                 $this->application->getConfig()->get('repo_adapter', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ADAPTER)
+            )
+        ;
+
+        $command
+            ->addOption(
+                'repo-adapter-config',
+                'rac',
+                InputOption::VALUE_REQUIRED,
+                'Config of the repository-manager',
+                $this->application->getConfig()->get('repo_adapter_config', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ADAPTER)
             )
         ;
 
@@ -112,6 +123,13 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
                 $issueTracker
             )
             ->addOption(
+                'issue-adapter-config',
+                'iac',
+                InputOption::VALUE_REQUIRED,
+                'Config of the issue-tracker',
+                $this->application->getConfig()->get('issue_tracker_config', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ADAPTER)
+            )
+            ->addOption(
                 'issue-org',
                 'io',
                 InputOption::VALUE_REQUIRED,
@@ -163,7 +181,7 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
 
         $this->validateAdaptersConfig($input);
 
-        $adapter = $this->getAdapter($adapterName);
+        $adapter = $this->getAdapter($adapterName, $input->getOption('repo-adapter-config'));
         $org = GitHelper::undefinedToDefault($input->getOption('org'));
         $repo = GitHelper::undefinedToDefault($input->getOption('repo'));
 
@@ -207,11 +225,13 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
     private function validateAdaptersConfig(InputInterface $input)
     {
         $repositoryManager = $input->getOption('repo-adapter');
+        $repositoryManagerConfig = $input->getOption('repo-adapter-config');
 
         $errors = [];
 
         $this->checkAdapterConfigured(
             $repositoryManager,
+            $repositoryManagerConfig,
             'repository-management',
             AdapterFactory::SUPPORT_REPOSITORY_MANAGER,
             $errors
@@ -219,9 +239,11 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
 
         if ($input->hasOption('issue-adapter')) {
             $issueTracker = $input->getOption('issue-adapter');
+            $issueTrackerConfig = $input->getOption('issue-adapter-config');
 
             $this->checkAdapterConfigured(
                 $issueTracker,
+                $issueTrackerConfig,
                 'issue-tracking',
                 AdapterFactory::SUPPORT_ISSUE_TRACKER,
                 $errors
@@ -237,11 +259,12 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
 
     /**
      * @param string   $adapter
+     * @param array    $adapterConfig
      * @param string   $typeLabel
      * @param string   $supports
      * @param string[] $errors
      */
-    private function checkAdapterConfigured($adapter, $typeLabel, $supports, array &$errors)
+    private function checkAdapterConfigured($adapter, $adapterConfig, $typeLabel, $supports, array &$errors)
     {
         $adapterFactory = $this->application->getAdapterFactory();
 
@@ -256,10 +279,11 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
             return;
         }
 
+        $hash = ConfigUtil::generateConfigurationIdentifier($adapter, $adapterConfig);
         $config = $this->application->getConfig();
 
-        if (!$config->has(['adapters', $adapter], Config::CONFIG_SYSTEM)) {
-            $errors[] = sprintf('Adapter "%s" (for %s) is not configured yet.', $adapter, $typeLabel);
+        if (!$config->has(['adapters', $hash], Config::CONFIG_SYSTEM)) {
+            $errors[] = sprintf('Adapter "%s" (for %s) is not configured yet.', $hash, $typeLabel);
         }
     }
 
@@ -267,21 +291,22 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
      * @param ConsoleCommandEvent $event
      * @param string              $org
      * @param string              $repo
-     * @param string              $adapterName
+     * @param string              $adapterConfig
      */
-    private function initializeIssueTracker(ConsoleCommandEvent $event, $org, $repo, $adapterName)
+    private function initializeIssueTracker(ConsoleCommandEvent $event, $org, $repo, $adapterConfig)
     {
         $input = $event->getInput();
 
         $issueOrg = GitHelper::undefinedToDefault($input->getOption('issue-org'), $org);
         $issueRepo = GitHelper::undefinedToDefault($input->getOption('issue-project'), $repo);
-        $issueAdapterName = $input->getOption('issue-adapter') ?: $adapterName;
+        $issueAdapterName = $input->getOption('issue-adapter') ?: $adapterConfig;
 
         $input->setOption('issue-org', $issueOrg);
         $input->setOption('issue-project', $issueRepo);
         $input->setOption('issue-adapter', $issueAdapterName);
 
-        $config = $this->application->getConfig()->get(['adapters', $issueAdapterName], Config::CONFIG_SYSTEM);
+        $hash = ConfigUtil::generateConfigurationIdentifier($issueAdapterName, $input->getOption('issue-adapter-config'));
+        $config = $this->application->getConfig()->get(['adapters', $hash], Config::CONFIG_SYSTEM);
 
         $issueTracker = $this->application->getAdapterFactory()->createIssueTracker(
             $issueAdapterName,
@@ -355,4 +380,5 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
 
         throw new UserException($exceptionMessage);
     }
+
 }

--- a/src/Subscriber/GitRepoSubscriber.php
+++ b/src/Subscriber/GitRepoSubscriber.php
@@ -279,11 +279,11 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
             return;
         }
 
-        $hash = ConfigUtil::generateConfigurationIdentifier($adapter, $adapterConfig);
+        $identifier = ConfigUtil::generateConfigurationIdentifier($adapter, $adapterConfig);
         $config = $this->application->getConfig();
 
-        if (!$config->has(['adapters', $hash], Config::CONFIG_SYSTEM)) {
-            $errors[] = sprintf('Adapter "%s" (for %s) is not configured yet.', $hash, $typeLabel);
+        if (!$config->has(['adapters', $identifier], Config::CONFIG_SYSTEM)) {
+            $errors[] = sprintf('Adapter "%s" (for %s) is not configured yet.', $identifier, $typeLabel);
         }
     }
 

--- a/src/Util/ConfigUtil.php
+++ b/src/Util/ConfigUtil.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Contains \Gush\Util\ConfigUtil.
+ */
+
+namespace Gush\Util;
+
+class ConfigUtil {
+
+  public static function generateConfigurationIdentifier($adapter, array $adapterConfig) {
+    return $adapter . ':' . substr(sha1(serialize($adapterConfig)), 0, 8);
+  }
+
+}


### PR DESCRIPTION
I tried to use gush with gitlab.com and our self-hosted corporate gitlab installation simultaneously, but the adapter config is keyed by adapter name. This means the two adapter settings override each other.

This PR add the concept of baseAdapter and configured adapter. This enables multiple adapter configurations. I think is also possible to replace the GitHub Enterprise and Jira Enterprise adapter with concept.

Example configuration in gush.yml

```
# Gush configuration file, any comments will be lost.
repo_adapter: gitlab:gitlab.mycompany.com
issue_tracker: gitlab:gitlab.mycompany.com
repo_org: foo
repo_name: bar
issue_project_org: foo
issue_project_name: bar
```

I opened a PR for the gitlab adapter. https://github.com/gushphp/gush-gitlab-adapter/pull/18