### PR TITLE
Remove -u flag when pulling from remote

### DIFF
--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -473,15 +473,9 @@ class GitHelper extends Helper
         $this->processHelper->runCommand($command);
     }
 
-    public function pullRemote($remote, $ref = null, $setUpstream = false)
+    public function pullRemote($remote, $ref = null)
     {
-        $command = ['git', 'pull'];
-
-        if ($setUpstream) {
-            $command[] = '-u';
-        }
-
-        $command[] = $remote;
+        $command = ['git', 'pull', $remote];
 
         if ($ref) {
             $command[] = $ref;


### PR DESCRIPTION
The -u flag does not set the upstream when used with git pull