### PR TITLE
Styleci bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ phpunit.xml
 /.bldr/vendor
 *.lock
 .bldr
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -9,6 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
+require_once __DIR__.'/vendor/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+use Symfony\CS\Fixer\Contrib\HeaderCommentFixer;
+
 $header = <<<EOF
 This file is part of Gush package.
 
@@ -18,33 +23,8 @@ This source file is subject to the MIT license that is bundled
 with this source code in the file LICENSE.
 EOF;
 
-Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
+HeaderCommentFixer::setHeader($header);
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
-    ->notName('OutputFixtures.php')
-    ->notName('phar-stub.php')
-    ->in(
-        [
-            __DIR__.'/src',
-            __DIR__.'/tests',
-        ]
-    )
-;
-
-// Load a local config-file when existing
-if (file_exists(__DIR__.'/local.php_cs')) {
-    require __DIR__.'/local.php_cs';
-}
-
-return Symfony\CS\Config\Config::create()
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers(
-        [
-            'header_comment',
-            'ordered_use',
-            'short_array_syntax',
-            '-psr0',
-        ]
-    )
-    ->finder($finder)
+return ConfigBridge::create(null, [__DIR__.'/src', __DIR__.'/tests'])
+    ->setUsingCache(true)
 ;

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,10 @@
+preset: symfony
+
+enabled:
+  - ordered_use
+  - short_array_syntax
+
+finder:
+  not-name:
+    - OutputFixtures.php
+    - phar-stub.php

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "gushphp/gush-github-adapter": "~1.2.0",
         "gushphp/gush-bitbucket-adapter": "~1.1.5",
         "gushphp/gush-gitlab-adapter": "~1.1.4",
-        "gushphp/gush-jira-adapter": "~1.1.7"
+        "gushphp/gush-jira-adapter": "~1.1.7",
+        "sllh/php-cs-fixer-styleci-bridge": "^1.3"
     },
     "require-dev": {
         "mikey179/vfsStream": "~1.5.0"

--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -420,7 +420,7 @@ class GitHelper extends Helper
         }
 
         $this->processHelper->runCommand(
-            ['git', 'merge', '--no-ff', '--log' , '--no-commit', $sourceBranch]
+            ['git', 'merge', '--no-ff', '--log', '--no-commit', $sourceBranch]
         );
 
         // Extract commits log


### PR DESCRIPTION
I saw that you are using both StyleCI and PHP-CS-Fixer.

I propose you to use this bridge that will parse your `.styleci.yml` file and configure your cs-fixer accordingly.

The goal of this PR is to have only one configuration file to maintain.

Note: If you already configured StyleCI on web interface, I suggest you to delete it except for the header_comment section.