### PR TITLE
Introduce operations for syncing and rebasing

### DIFF
--- a/src/Command/Branch/BranchSyncCommand.php
+++ b/src/Command/Branch/BranchSyncCommand.php
@@ -12,11 +12,14 @@
 namespace Gush\Command\Branch;
 
 use Gush\Command\BaseCommand;
+use Gush\Exception\UserException;
 use Gush\Feature\GitFolderFeature;
 use Gush\Feature\GitRepoFeature;
 use Gush\Helper\GitHelper;
+use Gush\Operation\GitSyncOperation;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class BranchSyncCommand extends BaseCommand implements GitRepoFeature, GitFolderFeature
@@ -28,19 +31,71 @@ class BranchSyncCommand extends BaseCommand implements GitRepoFeature, GitFolder
     {
         $this
             ->setName('branch:sync')
-            ->setDescription('Syncs local branch with its upstream version')
-            ->addArgument('branch_name', InputArgument::OPTIONAL, 'Branch name to sync')
+            ->setDescription('Synchronises the local branch with a remote branch')
+            ->addArgument('source_branch', InputArgument::OPTIONAL, 'Remote branch-name to use as source (base)')
+            ->addArgument('source_remote', InputArgument::OPTIONAL, 'Remote to pull from (defaults to [your-username])')
             ->addArgument(
-                'remote',
+                'dest_remote',
                 InputArgument::OPTIONAL,
-                'Git remote to pull from (defaults to origin)', 'origin'
+                'Remote to push changes to (defaults to [your-username])'
+            )
+            ->addArgument(
+                'dest_branch',
+                InputArgument::OPTIONAL,
+                'Remote branch to push changes to (defaults to the source_branch)'
+            )
+            ->addOption(
+                'strategy',
+                's',
+                InputOption::VALUE_REQUIRED,
+                sprintf(
+                    'Strategy to use for the synchronization process, eg: %s',
+                    implode(
+                        ', ',
+                        [GitSyncOperation::SYNC_FORCE, GitSyncOperation::SYNC_SMART, GitSyncOperation::SYNC_SMART_MERGE]
+                    )
+                ),
+                GitSyncOperation::SYNC_SMART
+            )
+            ->addOption(
+                'force-push',
+                'f',
+                InputOption::VALUE_NONE,
+                'Allow to push with force when this required (only used for smart and smart-merge), not recommended for shared branches!'
+            )
+            ->addOption(
+                'no-push',
+                'np',
+                InputOption::VALUE_NONE,
+                'Skip pushing of local changes, cannot be used in combination with --force-push'
             )
             ->setHelp(
                 <<<EOF
-The <info>%command.name%</info> command syncs local branch with it's origin version:
+The <info>%command.name%</info> command synchronises the current local branch with a remote branch.
 
-    <info>$ gush %command.name% develop origin</info>
+    <info>$ gush %command.name% master gushphp</info>
 
+This command supports various strategies for synchronizing, by default the 'smart' strategy
+is used which is best suited for most cases. But sometimes you may want to use something else.
+
+You can change the strategy with the <info>--strategy</> option.
+
+    <info>$ gush %command.name% --strategy=smart master gushphp</info>
+
+Gush supports the following strategies:
+
+* force: Forces the local branch to equal the remote version (this is the equivalent of using git reset --hard remote/branch).
+
+* smart: Determines what is best to use, pull --rebase or push.
+
+* smart-merge: Same as 'smart' but uses merge instead of rebase for pulling-in changes.
+
+<comment>Note: Gush will refuse to push with force (when a rebase is performed) unless you either explicitly
+provide a "dest_remote" or supply the use '--force-push' option.</>
+
+    <info>$ gush %command.name% --strategy=smart --force-push master gushphp</info>
+
+If you rather don't want to push your local changes you can use the <comment>--no-push</> option.
 EOF
             )
         ;
@@ -51,20 +106,51 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($input->getOption('no-push') && $input->getOption('force-push')) {
+            throw new UserException('Can only use --no-push or --force-push (not both).');
+        }
+
         /** @var GitHelper $gitHelper */
         $gitHelper = $this->getHelper('git');
 
-        $remote = $input->getArgument('remote');
-        $branchName = $input->getArgument('branch_name');
+        $sourceRemote = $input->getArgument('source_remote');
+        $sourceBranch = $input->getArgument('source_branch');
 
-        if (null === $branchName) {
-            $branchName = $gitHelper->getActiveBranchName();
+        if (null === $sourceRemote) {
+            $sourceRemote = $this->getParameter($input, 'authentication')['username'];
         }
 
-        $gitHelper->syncWithRemote($remote, $branchName);
+        if (null === $sourceBranch) {
+            $sourceBranch = $gitHelper->getActiveBranchName();
+        }
+
+        $destRemote = $input->getArgument('dest_remote');
+        $destBranch = $input->getArgument('dest_branch');
+
+        if (null === $destRemote) {
+            $destRemote = $this->getParameter($input, 'authentication')['username'];
+        }
+
+        if (null === $destBranch) {
+            $destBranch = $sourceBranch;
+        }
+
+        $options = 0;
+
+        if ($input->getOption('no-push')) {
+            $options |= GitSyncOperation::DISABLE_PUSH;
+        } elseif (null !== $input->getArgument('dest_remote') || (bool) $input->getOption('force-push')) {
+            $options |= GitSyncOperation::FORCE_PUSH;
+        }
+
+        $syncOperation = $gitHelper->createSyncOperation();
+        $syncOperation->setLocalRef($gitHelper->getActiveBranchName());
+        $syncOperation->setRemoteRef($sourceRemote, $sourceBranch);
+        $syncOperation->setRemoteDestination($destRemote, $destBranch);
+        $syncOperation->sync($input->getOption('strategy'), $options);
 
         $this->getHelper('gush_style')->success(
-            sprintf('Branch "%s" has been synced with remote "%s".', $branchName, $remote)
+            sprintf('Branch "%s" has been synchronised with remote "%s".', $sourceBranch, $sourceRemote)
         );
 
         return self::COMMAND_SUCCESS;

--- a/src/Operation/GitSyncOperation.php
+++ b/src/Operation/GitSyncOperation.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Operation;
+
+use Gush\Helper\GitHelper;
+use Gush\Helper\ProcessHelper;
+
+class GitSyncOperation
+{
+    /**
+     * Sync by forcing the local branch to equal the remote.
+     */
+    const SYNC_FORCE = 'force';
+
+    /**
+     * Sync by being smart.
+     *
+     * * If both are up-to-date do nothing.
+     * * If a pull is required, do it (using a rebase).
+     * * If a push is required, do it.
+     */
+    const SYNC_SMART = 'smart';
+
+    /**
+     * Sync by being smart (but don't use rebase for merging remote changes).
+     *
+     * * If both are up-to-date do nothing.
+     * * If a pull is required, do it (using with a merge).
+     * * If a push is required, do it.
+     */
+    const SYNC_SMART_MERGE = 'smart-merge';
+
+    const DISABLE_PUSH = 1;
+    const FORCE_PUSH = 2;
+
+    private $gitHelper;
+    private $processHelper;
+
+    private $sourceRemote;
+    private $sourceBranch;
+    private $localBranch;
+
+    private $destinationRemote;
+    private $destinationBranch;
+
+    public function __construct(GitHelper $gitHelper, ProcessHelper $processHelper)
+    {
+        $this->gitHelper = $gitHelper;
+        $this->processHelper = $processHelper;
+    }
+
+    public function setLocalRef($branch)
+    {
+        $this->localBranch = $branch;
+
+        return $this;
+    }
+
+    public function setRemoteRef($remote, $branch)
+    {
+        $this->sourceRemote = $remote;
+        $this->sourceBranch = $branch;
+
+        return $this;
+    }
+
+    public function setRemoteDestination($remote, $branch)
+    {
+        $this->destinationRemote = $remote;
+        $this->destinationBranch = $branch;
+
+        return $this;
+    }
+
+    public function sync($type = self::SYNC_FORCE, $options)
+    {
+        if ($options & self::DISABLE_PUSH && $options & self::FORCE_PUSH) {
+            throw new \InvalidArgumentException('Cannot use both DISABLE_PUSH and FORCE_PUSH.');
+        }
+
+        $this->gitHelper->guardWorkingTreeReady();
+        $this->gitHelper->stashBranchName();
+
+        $this->gitHelper->remoteUpdate($this->sourceRemote);
+        $this->gitHelper->remoteUpdate($this->destinationRemote);
+
+        $this->gitHelper->guardBranchExist($this->localBranch);
+        $this->gitHelper->guardRemoteBranchExists($this->sourceRemote, $this->sourceBranch);
+
+        $status = $this->gitHelper->getRemoteDiffStatus($this->sourceRemote, $this->localBranch, $this->sourceBranch);
+
+        // All up-to-date, nothing to do.
+        if (GitHelper::STATUS_UP_TO_DATE === $status) {
+            return;
+        }
+
+        $this->gitHelper->checkout($this->localBranch);
+
+        if (self::SYNC_FORCE === $type) {
+            $this->gitHelper->reset($this->sourceRemote.'/'.$this->sourceBranch, 'hard');
+
+            return;
+        }
+
+        switch ($status) {
+            case GitHelper::STATUS_NEED_PULL:
+            case GitHelper::STATUS_DIVERGED:
+                if (self::SYNC_SMART === $type) {
+                    $this->gitHelper->createRebaseOperation(
+                        $this->sourceRemote.'/'.$this->sourceBranch
+                    )->performRebase();
+                } else {
+                    $this->processHelper->runCommand(
+                        ['git', 'merge', '--ff', '--no-log', $this->sourceRemote.'/'.$this->sourceBranch]
+                    );
+                }
+
+                if (GitHelper::STATUS_DIVERGED === $status && !($options & self::DISABLE_PUSH)) {
+                    $this->pushToRemote((bool) ($options & self::FORCE_PUSH));
+                }
+                break;
+
+            case GitHelper::STATUS_NEED_PUSH:
+                if (!($options & self::DISABLE_PUSH)) {
+                    $this->pushToRemote();
+                }
+                break;
+
+            default:
+                throw new \InvalidArgumentException('Unsupported sync option provided: '.$type);
+        }
+    }
+
+    private function pushToRemote($force = false)
+    {
+        $target = trim($this->localBranch).':'.$this->destinationBranch;
+
+        // Safety guard to prevent deleting a remote base branch!!
+        if (':' === $target[0]) {
+            throw new \RuntimeException(
+                sprintf('Push target "%s" does not include the local branch-name, please report this bug!', $target)
+            );
+        }
+
+        $this->gitHelper->pushToRemote($this->destinationRemote, $target, false, $force);
+    }
+}

--- a/src/Operation/RebaseOperation.php
+++ b/src/Operation/RebaseOperation.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Operation;
+
+use Gush\Helper\GitHelper;
+use Gush\Helper\ProcessHelper;
+
+/**
+ * A rebase operation should only be used by other processes
+ * and not directly within commands.
+ */
+final class RebaseOperation
+{
+    private $gitHelper;
+    private $processHelper;
+
+    private $base;
+    private $newBase;
+    private $currentBase;
+    private $performed;
+    private $branch;
+
+    public function __construct(GitHelper $gitHelper, ProcessHelper $processHelper)
+    {
+        $this->gitHelper = $gitHelper;
+        $this->processHelper = $processHelper;
+    }
+
+    public function setBase($base)
+    {
+        $this->base = $base;
+
+        return $this;
+    }
+
+    public function onto($newBase, $currentBase, $branch)
+    {
+        $this->newBase = $newBase;
+        $this->currentBase = $currentBase;
+        $this->branch = $branch;
+
+        return $this;
+    }
+
+    public function performRebase()
+    {
+        if ($this->performed) {
+            throw new \RuntimeException('performRebase() was already called. Each operation is only usable once.');
+        }
+
+        try {
+            $command = [
+                'git',
+                'rebase',
+            ];
+
+            if ($this->newBase) {
+                $command[] = '--onto';
+                $command[] = $this->newBase;
+                $command[] = $this->base;
+                $command[] = $this->branch;
+            } else {
+                $command[] = $this->base;
+            }
+
+            $this->processHelper->runCommand($command);
+        } catch (\Exception $e) {
+            // Error, abort the rebase process
+            $this->processHelper->runCommand(['git', 'rebase', '--abort'], true);
+
+            throw $e;
+        }
+
+        $this->performed = true;
+    }
+}


### PR DESCRIPTION
|Q            |A   |
|---          |--- |
|Fixed Tickets| #410  |
|License      |MIT |

**This is a work in progress (extensive testing is required).**

Test:

Try all with need pull/push and diverged.

- [x] force
- [ ] smart with auto remote and branch
- [ ] smart with explicit remote and branch
- [ ] smart-merge
- [ ] smart with `--no-push`
- [ ] smart with auto remote and branch plus `--force-push`

The `branch:sync` command now supports three ways of synchronizing (both ways):

* FORCE: `git reset --hard remote/source-branch`
* SMART:  Determines what is best, rebase or push (default)
* SMART_MERGE_ONLY: Same as SMART but uses merge instead of rebase for pulling-in changes.

All except force ensure the local branch is updated (rebase or merge) with the remote branch and pushes when done (can be disabled).

Internally this uses the new `GitSyncOperation` class which can also be used for `pull-request:squash`, `pull-request:rebase` (coming soon) and `pull-request:switch-base`.