### PR TITLE
minor improvements to GitHelper

### DIFF
--- a/src/Command/Branch/BranchDeleteCommand.php
+++ b/src/Command/Branch/BranchDeleteCommand.php
@@ -15,6 +15,7 @@ use Gush\Command\BaseCommand;
 use Gush\Exception\UserException;
 use Gush\Feature\GitDirectoryFeature;
 use Gush\Feature\GitRepoFeature;
+use Gush\Helper\GitHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -101,7 +102,7 @@ EOF
 
         $this->guardProtectedBranches($input, $branchName);
 
-        $this->getHelper('git')->pushToRemote($org, ':'.$branchName, true);
+        $this->getHelper('git')->pushToRemote($org, ':'.$branchName, GitHelper::ALLOW_DELETE);
 
         $this->getHelper('gush_style')->success(
             sprintf('Branch %s/%s has been deleted!', $org, $branchName)

--- a/src/Command/Branch/BranchDeleteCommand.php
+++ b/src/Command/Branch/BranchDeleteCommand.php
@@ -102,7 +102,7 @@ EOF
 
         $this->guardProtectedBranches($input, $branchName);
 
-        $this->getHelper('git')->pushToRemote($org, ':'.$branchName, GitHelper::ALLOW_DELETE);
+        $this->getHelper('git')->deleteRemoteBranch($org, $branchName);
 
         $this->getHelper('gush_style')->success(
             sprintf('Branch %s/%s has been deleted!', $org, $branchName)

--- a/src/Command/Branch/BranchPushCommand.php
+++ b/src/Command/Branch/BranchPushCommand.php
@@ -14,6 +14,7 @@ namespace Gush\Command\Branch;
 use Gush\Command\BaseCommand;
 use Gush\Feature\GitDirectoryFeature;
 use Gush\Feature\GitRepoFeature;
+use Gush\Helper\GitHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -69,12 +70,17 @@ EOF
             $org = $this->getParameter($input, 'authentication')['username'];
         }
 
-        $this->getHelper('git')->pushToRemote(
-            $org,
-            $branchName,
-            (bool) $input->getOption('set-upstream'),
-            (bool) $input->getOption('force')
-        );
+        $options = 0;
+
+        if ($input->getOption('set-upstream')) {
+            $options |= GitHelper::SET_UPSTREAM;
+        }
+
+        if ($input->getOption('force')) {
+            $options |= GitHelper::PUSH_FORCE;
+        }
+
+        $this->getHelper('git')->pushToRemote($org, $branchName, $options);
 
         $this->getHelper('gush_style')->success(
             sprintf('Branch pushed to %s/%s', $org, $branchName)

--- a/src/Command/Core/InitCommand.php
+++ b/src/Command/Core/InitCommand.php
@@ -15,8 +15,8 @@ use Gush\Command\BaseCommand;
 use Gush\Config;
 use Gush\ConfigFactory;
 use Gush\Feature\GitDirectoryFeature;
-use Gush\Helper\GitHelper;
 use Gush\Helper\StyleHelper;
+use Gush\Util\AdapterConfigUtil;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -54,7 +54,7 @@ EOF
             $styleHelper->numberedChoice(
                 'Choose repository-manager',
                 $adapters[0],
-                GitHelper::undefinedToDefault($input->getOption('repo-adapter'))
+                AdapterConfigUtil::undefinedToDefault($input->getOption('repo-adapter'))
             )
         );
 
@@ -63,7 +63,7 @@ EOF
             $styleHelper->numberedChoice(
                 'Choose issue-tracker',
                 $adapters[1],
-                GitHelper::undefinedToDefault($input->getOption('issue-adapter'))
+                AdapterConfigUtil::undefinedToDefault($input->getOption('issue-adapter'))
             )
         );
 
@@ -71,7 +71,7 @@ EOF
             'org',
             $styleHelper->ask(
                 'Specify the repository organization name',
-                GitHelper::undefinedToDefault($input->getOption('org')),
+                AdapterConfigUtil::undefinedToDefault($input->getOption('org')),
                 ['\Gush\Util\CliValidator', 'notEmpty']
             )
         );
@@ -80,7 +80,7 @@ EOF
             'repo',
             $styleHelper->ask(
                 'Specify the repository name',
-                GitHelper::undefinedToDefault($input->getOption('repo')),
+                AdapterConfigUtil::undefinedToDefault($input->getOption('repo')),
                 ['\Gush\Util\CliValidator', 'notEmpty']
             )
         );
@@ -89,7 +89,7 @@ EOF
             'issue-org',
             $styleHelper->ask(
                 'Specify the issue-tracker organization name',
-                GitHelper::undefinedToDefault($input->getOption('issue-org'), $input->getOption('org')),
+                AdapterConfigUtil::undefinedToDefault($input->getOption('issue-org'), $input->getOption('org')),
                 ['\Gush\Util\CliValidator', 'notEmpty']
             )
         );
@@ -98,7 +98,7 @@ EOF
             'issue-project',
             $styleHelper->ask(
                 'Specify the issue-tracker repository/project name',
-                GitHelper::undefinedToDefault($input->getOption('issue-project'), $input->getOption('repo')),
+                AdapterConfigUtil::undefinedToDefault($input->getOption('issue-project'), $input->getOption('repo')),
                 ['\Gush\Util\CliValidator', 'notEmpty']
             )
         );
@@ -121,14 +121,14 @@ EOF
         $repositoryManagers = $adapters[0];
         $issueTrackers = $adapters[1];
 
-        $repositoryManager = GitHelper::undefinedToDefault($input->getOption('repo-adapter'));
-        $issueTracker = GitHelper::undefinedToDefault($input->getOption('issue-adapter'));
+        $repositoryManager = AdapterConfigUtil::undefinedToDefault($input->getOption('repo-adapter'));
+        $issueTracker = AdapterConfigUtil::undefinedToDefault($input->getOption('issue-adapter'));
 
-        $org = GitHelper::undefinedToDefault($input->getOption('org'));
-        $repo = GitHelper::undefinedToDefault($input->getOption('repo'));
+        $org = AdapterConfigUtil::undefinedToDefault($input->getOption('org'));
+        $repo = AdapterConfigUtil::undefinedToDefault($input->getOption('repo'));
 
-        $issueOrg = GitHelper::undefinedToDefault($input->getOption('issue-org'), $org);
-        $issueRepo = GitHelper::undefinedToDefault($input->getOption('issue-project'), $repo);
+        $issueOrg = AdapterConfigUtil::undefinedToDefault($input->getOption('issue-org'), $org);
+        $issueRepo = AdapterConfigUtil::undefinedToDefault($input->getOption('issue-project'), $repo);
 
         $this->validateAdapter($repositoryManager, $repositoryManagers, 'Repository-manager', $valid);
         $this->validateAdapter($issueTracker, $issueTrackers, 'Issue-tracker', $valid);

--- a/src/Command/PullRequest/PullRequestCreateCommand.php
+++ b/src/Command/PullRequest/PullRequestCreateCommand.php
@@ -206,6 +206,8 @@ EOF
     {
         /** @var GitHelper $gitHelper */
         $gitHelper = $this->getHelper('git');
+        /** @var GitConfigHelper $gitConfigHelper */
+        $gitConfigHelper = $this->getHelper('git_config');
 
         $gitUrl = $this->getAdapter()->getRepositoryInfo($org, $repo)['push_url'];
 
@@ -215,7 +217,7 @@ EOF
 
         if ($gitHelper->branchExists($branch)) {
             $this->guardRemoteUpdated($org, $repo);
-            $gitHelper->pushToRemote($org, $branch, true);
+            $gitHelper->pushToRemote($org, $branch, GitHelper::SET_UPSTREAM);
 
             $styleHelper->note(sprintf('Branch "%s" was pushed to "%s".', $branch, $org));
 

--- a/src/Command/PullRequest/PullRequestFixerCommand.php
+++ b/src/Command/PullRequest/PullRequestFixerCommand.php
@@ -67,7 +67,7 @@ EOF
                 'Your working tree has uncommitted changes, committing changes with "WIP" as message.'
             );
 
-            $gitHelper->commit('wip', ['a']);
+            $gitHelper->commit('wip', GitHelper::COMMIT_ALL);
         }
 
         $processHelper->runCommand($fixerLine, true);
@@ -75,7 +75,7 @@ EOF
         $gitHelper->add('.');
 
         if (!$gitHelper->isWorkingTreeReady()) {
-            $gitHelper->commit('cs-fixer', ['a']);
+            $gitHelper->commit('cs-fixer', GitHelper::COMMIT_ALL);
         }
 
         $this->getHelper('gush_style')->success('CS fixes committed!');

--- a/src/Command/PullRequest/PullRequestSquashCommand.php
+++ b/src/Command/PullRequest/PullRequestSquashCommand.php
@@ -38,6 +38,12 @@ class PullRequestSquashCommand extends BaseCommand implements GitRepoFeature, Gi
                 InputOption::VALUE_NONE,
                 'Do not sync the local branch with the squashed version'
             )
+            ->addOption(
+                'force',
+                null,
+                InputOption::VALUE_NONE,
+                'Force squashing the PR, even if there are multiple authors'
+            )
             ->addArgument('pr_number', InputArgument::REQUIRED, 'pull-request number to squash')
             ->setHelp(
                 <<<EOF
@@ -87,8 +93,8 @@ EOF
         $gitHelper->stashBranchName();
         $gitHelper->checkout($sourceBranch);
         $gitHelper->checkout($tmpBranch = $gitHelper->createTempBranch($sourceBranch), true);
-        $gitHelper->squashCommits($baseOrg.'/'.$baseBranch, $tmpBranch);
-        $gitHelper->pushToRemote($sourceOrg, $tmpBranch.':'.$sourceBranch, false, true);
+        $gitHelper->squashCommits($baseOrg.'/'.$baseBranch, $tmpBranch, $input->getOption('force') ? GitHelper::IGNORE_MULTIPLE_AUTHORS : 0);
+        $gitHelper->pushToRemote($sourceOrg, $tmpBranch.':'.$sourceBranch, GitHelper::PUSH_FORCE);
 
         if (!$input->getOption('no-local-sync') && $gitHelper->branchExists($sourceBranch)) {
             $gitHelper->checkout($sourceBranch);

--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -28,15 +28,11 @@ class GitHelper extends Helper
     const PUSH_FORCE = 2;
     const ALLOW_DELETE = 4;
 
-    // Merge
-    const MERGE_FF = 8;
-    const MERGE_NO_FF = 16;
-
     // Squash
-    const IGNORE_MULTIPLE_AUTHORS = 32;
+    const IGNORE_MULTIPLE_AUTHORS = 8;
 
     // Various
-    const COMMIT_ALL = 64;
+    const COMMIT_ALL = 16;
 
     /** @var ProcessHelper */
     private $processHelper;
@@ -366,24 +362,17 @@ class GitHelper extends Helper
      * @param string $base          The base branch name
      * @param string $sourceBranch  The source branch name
      * @param string $commitMessage Commit message to use for the merge-commit
-     * @param int    $options       Bitmask options (self::MERGE_FF or self::MERGE_NO_FF)
      *
      * @throws WorkingTreeIsNotReady
      *
-     * @return null|string The merge-commit hash or null when fast-forward was used
+     * @return string
      */
-    public function mergeBranch($base, $sourceBranch, $commitMessage, $options = self::MERGE_NO_FF)
+    public function mergeBranch($base, $sourceBranch, $commitMessage)
     {
         $this->guardWorkingTreeReady();
         $this->stashBranchName();
 
         $this->checkout($base);
-
-        if ($options & self::MERGE_FF) {
-            $this->processHelper->runCommand(['git', 'merge', '--ff', $sourceBranch]);
-
-            return trim($this->processHelper->runCommand('git rev-parse HEAD'));
-        }
 
         $tmpName = $this->filesystemHelper->newTempFilename();
         file_put_contents($tmpName, $commitMessage);
@@ -402,6 +391,22 @@ class GitHelper extends Helper
         );
 
         return trim($this->processHelper->runCommand('git rev-parse HEAD'));
+    }
+
+    /**
+     * @param string $base          The base branch name
+     * @param string $sourceBranch  The source branch name
+     *
+     * @throws WorkingTreeIsNotReady
+     */
+    public function mergeBranchFastForward($base, $sourceBranch)
+    {
+        $this->guardWorkingTreeReady();
+        $this->stashBranchName();
+
+        $this->checkout($base);
+
+        $this->processHelper->runCommand(['git', 'merge', '--ff', $sourceBranch]);
     }
 
     /**

--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -472,12 +472,9 @@ class GitHelper extends Helper
 
     public function pushToRemote($remote, $ref, $options = 0)
     {
-        if (!($options & self::ALLOW_DELETE) && ':' === $ref[0]) {
+        if (':' === $ref[0]) {
             throw new \RuntimeException(
-                sprintf(
-                    'Push target "%s" does not include a local branch and deletion is not enabled, please report this bug!',
-                    $ref
-                )
+                sprintf('Push target "%s" does not include a local branch, please report this bug!', $ref)
             );
         }
 
@@ -494,6 +491,11 @@ class GitHelper extends Helper
         $command[] = $ref;
 
         $this->processHelper->runCommand($command);
+    }
+
+    public function deleteRemoteBranch($remote, $ref)
+    {
+        $this->processHelper->runCommand(['git', 'push', $remote, ':'.$ref]);
     }
 
     public function pullRemote($remote, $ref = null)

--- a/src/Operation/RemoteMergeOperation.php
+++ b/src/Operation/RemoteMergeOperation.php
@@ -115,12 +115,16 @@ class RemoteMergeOperation
                 $this->message,
                 $this->sourceBranch
             );
+        } elseif ($this->fastForward) {
+            $mergeHash = $this->gitHelper->mergeBranchFastForward(
+                $this->targetBase,
+                $tempSourceBranch
+            );
         } else {
             $mergeHash = $this->gitHelper->mergeBranch(
                 $this->targetBase,
                 $tempSourceBranch,
-                $this->message,
-                $this->fastForward ? GitHelper::MERGE_FF : GitHelper::MERGE_NO_FF
+                $this->message
             );
         }
 

--- a/src/Operation/RemoteMergeOperation.php
+++ b/src/Operation/RemoteMergeOperation.php
@@ -108,7 +108,7 @@ class RemoteMergeOperation
 
         $tempSourceBranch = $this->createSourceBranch();
 
-        if ($this->withLog) {
+        if ($this->withLog && !$this->fastForward) {
             $mergeHash = $this->gitHelper->mergeBranchWithLog(
                 $this->targetBase,
                 $tempSourceBranch,
@@ -120,7 +120,7 @@ class RemoteMergeOperation
                 $this->targetBase,
                 $tempSourceBranch,
                 $this->message,
-                $this->fastForward
+                $this->fastForward ? GitHelper::MERGE_FF : GitHelper::MERGE_NO_FF
             );
         }
 
@@ -171,7 +171,11 @@ class RemoteMergeOperation
         }
 
         if ($this->squash) {
-            $this->gitHelper->squashCommits($this->targetBase, $sourceBranch, $this->forceSquash);
+            $this->gitHelper->squashCommits(
+                $this->targetBase,
+                $sourceBranch,
+                $this->forceSquash ? GitHelper::IGNORE_MULTIPLE_AUTHORS : 0
+            );
         }
 
         // Allow a callback to allow late commits list composition

--- a/src/Operation/RemotePatchOperation.php
+++ b/src/Operation/RemotePatchOperation.php
@@ -71,7 +71,7 @@ final class RemotePatchOperation
         $this->gitHelper->checkout($this->tempBranch, true);
 
         $this->processHelper->runCommand(['patch', '-'.$type, '--input', $patchFile]);
-        $this->gitHelper->commit($message, ['a']);
+        $this->gitHelper->commit($message, GitHelper::COMMIT_ALL);
 
         $this->gitHelper->restoreStashedBranch();
     }

--- a/src/Subscriber/CoreInitSubscriber.php
+++ b/src/Subscriber/CoreInitSubscriber.php
@@ -17,6 +17,7 @@ use Gush\Event\GushEvents;
 use Gush\Exception\UserException;
 use Gush\Factory\AdapterFactory;
 use Gush\Helper\GitHelper;
+use Gush\Util\AdapterConfigUtil;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\Input\InputOption;
@@ -39,8 +40,8 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
             return;
         }
 
-        $adapterName = $this->application->getConfig()->get('repo_adapter', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ADAPTER);
-        $issueTracker = $this->application->getConfig()->get('issue_tracker', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ADAPTER);
+        $adapterName = $this->application->getConfig()->get('repo_adapter', Config::CONFIG_LOCAL, AdapterConfigUtil::UNDEFINED_ADAPTER);
+        $issueTracker = $this->application->getConfig()->get('issue_tracker', Config::CONFIG_LOCAL, AdapterConfigUtil::UNDEFINED_ADAPTER);
 
         $command
             ->addOption(
@@ -69,14 +70,14 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
                 'o',
                 InputOption::VALUE_REQUIRED,
                 'Name of the Git organization',
-                $this->application->getConfig()->get('repo_org', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ORG)
+                $this->application->getConfig()->get('repo_org', Config::CONFIG_LOCAL, AdapterConfigUtil::UNDEFINED_ORG)
             )
             ->addOption(
                 'repo',
                 'r',
                 InputOption::VALUE_REQUIRED,
                 'Name of the Git repository',
-                $this->application->getConfig()->get('repo_name', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_REPO)
+                $this->application->getConfig()->get('repo_name', Config::CONFIG_LOCAL,AdapterConfigUtil::UNDEFINED_REPO)
             )
 
             ->addOption(
@@ -87,7 +88,7 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
                 $this->application->getConfig()->getFirstNotNull(
                     ['issue_project_org', 'repo_org'],
                     Config::CONFIG_LOCAL,
-                    GitHelper::UNDEFINED_ORG
+                    AdapterConfigUtil::UNDEFINED_ORG
                 )
             )
             ->addOption(
@@ -98,7 +99,7 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
                 $this->application->getConfig()->getFirstNotNull(
                     ['issue_project', 'repo_name'],
                     Config::CONFIG_LOCAL,
-                    GitHelper::UNDEFINED_REPO
+                    AdapterConfigUtil::UNDEFINED_REPO
                 )
             )
         ;
@@ -132,12 +133,12 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
 
         $input->setOption(
             'repo-adapter',
-            GitHelper::undefinedToDefault($input->getOption('repo-adapter'), $this->detectAdapterName())
+            AdapterConfigUtil::undefinedToDefault($input->getOption('repo-adapter'), $this->detectAdapterName())
         );
 
         $input->setOption(
             'issue-adapter',
-            GitHelper::undefinedToDefault(
+            AdapterConfigUtil::undefinedToDefault(
                 $input->getOption('issue-adapter'),
                 $input->getOption('repo-adapter')
             )
@@ -147,8 +148,8 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
             return;
         }
 
-        $org = GitHelper::undefinedToDefault($input->getOption('org'));
-        $repo = GitHelper::undefinedToDefault($input->getOption('repo'));
+        $org = AdapterConfigUtil::undefinedToDefault($input->getOption('org'));
+        $repo = AdapterConfigUtil::undefinedToDefault($input->getOption('repo'));
 
         if (null === $org || null === $repo) {
             list($org, $repo) = $this->getRepositoryReference(
@@ -171,8 +172,10 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
             $input->setOption('repo', $repo);
         }
 
-        $input->setOption('issue-org', GitHelper::undefinedToDefault($input->getOption('issue-org'), $org));
-        $input->setOption('issue-project', GitHelper::undefinedToDefault($input->getOption('issue-project'), $repo));
+        $input->setOption('issue-org', AdapterConfigUtil::undefinedToDefault($input->getOption('issue-org'), $org));
+        $input->setOption('issue-project',
+            AdapterConfigUtil::undefinedToDefault($input->getOption('issue-project'), $repo)
+        );
     }
 
     /**
@@ -203,7 +206,5 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
                 return $adapterName;
             };
         }
-
-        return;
     }
 }

--- a/src/Subscriber/GitRepoSubscriber.php
+++ b/src/Subscriber/GitRepoSubscriber.php
@@ -19,6 +19,7 @@ use Gush\Factory\AdapterFactory;
 use Gush\Feature\GitRepoFeature;
 use Gush\Feature\IssueTrackerRepoFeature;
 use Gush\Helper\GitHelper;
+use Gush\Util\AdapterConfigUtil;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -51,7 +52,9 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
                     'Adapter-name of the repository-manager (%s)',
                     $this->getSupportedAdapters(AdapterFactory::SUPPORT_REPOSITORY_MANAGER)
                 ),
-                $this->application->getConfig()->get('repo_adapter', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ADAPTER)
+                $this->application->getConfig()->get('repo_adapter', Config::CONFIG_LOCAL,
+                    AdapterConfigUtil::UNDEFINED_ADAPTER
+                )
             )
         ;
 
@@ -68,14 +71,16 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
                 'o',
                 InputOption::VALUE_REQUIRED,
                 'Name of the Git organization',
-                $this->application->getConfig()->get('repo_org', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_ORG)
+                $this->application->getConfig()->get('repo_org', Config::CONFIG_LOCAL, AdapterConfigUtil::UNDEFINED_ORG)
             )
             ->addOption(
                 'repo',
                 'r',
                 InputOption::VALUE_REQUIRED,
                 'Name of the Git repository',
-                $this->application->getConfig()->get('repo_name', Config::CONFIG_LOCAL, GitHelper::UNDEFINED_REPO)
+                $this->application->getConfig()->get('repo_name', Config::CONFIG_LOCAL,
+                    AdapterConfigUtil::UNDEFINED_REPO
+                )
             )
         ;
 
@@ -97,7 +102,7 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
         $issueTracker = $this->application->getConfig()->get(
             'issue_tracker',
             Config::CONFIG_LOCAL,
-            GitHelper::UNDEFINED_ADAPTER
+            AdapterConfigUtil::UNDEFINED_ADAPTER
         );
 
         $command
@@ -119,7 +124,7 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
                 $this->application->getConfig()->getFirstNotNull(
                     ['issue_project_org', 'repo_org'],
                     Config::CONFIG_LOCAL,
-                    GitHelper::UNDEFINED_ORG
+                    AdapterConfigUtil::UNDEFINED_ORG
                 )
             )
             ->addOption(
@@ -130,7 +135,7 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
                 $this->application->getConfig()->getFirstNotNull(
                     ['issue_project_name', 'repo_name'],
                     Config::CONFIG_LOCAL,
-                    GitHelper::UNDEFINED_REPO
+                    AdapterConfigUtil::UNDEFINED_REPO
                 )
             )
         ;
@@ -147,7 +152,7 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
 
         $input = $event->getInput();
 
-        if (GitHelper::UNDEFINED_ADAPTER === $input->getOption('repo-adapter')) {
+        if (AdapterConfigUtil::UNDEFINED_ADAPTER === $input->getOption('repo-adapter')) {
             $input->setOption('repo-adapter', $this->detectAdapterName());
         }
 
@@ -155,7 +160,7 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
         $adapterName = $input->getOption('repo-adapter');
 
         if ($input->hasOption('issue-adapter') &&
-            GitHelper::UNDEFINED_ADAPTER === $input->getOption('issue-adapter') &&
+            AdapterConfigUtil::UNDEFINED_ADAPTER === $input->getOption('issue-adapter') &&
             $adapterFactory->supports($adapterName, AdapterFactory::SUPPORT_ISSUE_TRACKER)
         ) {
             $input->setOption('issue-adapter', $adapterName);
@@ -164,8 +169,8 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
         $this->validateAdaptersConfig($input);
 
         $adapter = $this->getAdapter($adapterName);
-        $org = GitHelper::undefinedToDefault($input->getOption('org'));
-        $repo = GitHelper::undefinedToDefault($input->getOption('repo'));
+        $org = AdapterConfigUtil::undefinedToDefault($input->getOption('org'));
+        $repo = AdapterConfigUtil::undefinedToDefault($input->getOption('repo'));
 
         $this->application->setAdapter($adapter);
 
@@ -273,8 +278,8 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
     {
         $input = $event->getInput();
 
-        $issueOrg = GitHelper::undefinedToDefault($input->getOption('issue-org'), $org);
-        $issueRepo = GitHelper::undefinedToDefault($input->getOption('issue-project'), $repo);
+        $issueOrg = AdapterConfigUtil::undefinedToDefault($input->getOption('issue-org'), $org);
+        $issueRepo = AdapterConfigUtil::undefinedToDefault($input->getOption('issue-project'), $repo);
         $issueAdapterName = $input->getOption('issue-adapter') ?: $adapterName;
 
         $input->setOption('issue-org', $issueOrg);

--- a/src/Util/AdapterConfigUtil.php
+++ b/src/Util/AdapterConfigUtil.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Util;
+
+final class AdapterConfigUtil
+{
+    // Use a null character to ensure the name can never a legal name
+    // and help with detecting its undefined
+    const UNDEFINED_ORG = "org-autodetected\0";
+    const UNDEFINED_REPO = "repo-autodetected\0";
+    const UNDEFINED_ADAPTER = "adapter-autodetected\0";
+
+    /**
+     * @param string      $value
+     * @param string|null $default
+     *
+     * @return null|string
+     */
+    public static function undefinedToDefault($value, $default = null)
+    {
+        if (false !== strpos($value, "\0")) {
+            return $default;
+        }
+
+        return $value;
+    }
+}

--- a/tests/Command/Branch/BranchDeleteCommandTest.php
+++ b/tests/Command/Branch/BranchDeleteCommandTest.php
@@ -13,6 +13,7 @@ namespace Gush\Tests\Command\Branch;
 
 use Gush\Command\Branch\BranchDeleteCommand;
 use Gush\Exception\UserException;
+use Gush\Helper\GitHelper;
 use Gush\Tests\Command\CommandTestCase;
 use Symfony\Component\Console\Helper\HelperSet;
 
@@ -118,9 +119,9 @@ class BranchDeleteCommandTest extends CommandTestCase
         $helper->getActiveBranchName()->willReturn($branchName);
 
         if ($pushed) {
-            $helper->pushToRemote($remote, ':'.$deletedBranch, true)->shouldBeCalled();
+            $helper->pushToRemote($remote, ':'.$deletedBranch, GitHelper::ALLOW_DELETE)->shouldBeCalled();
         } else {
-            $helper->pushToRemote($remote, ':'.$deletedBranch, true)->shouldNotBeCalled();
+            $helper->pushToRemote($remote, ':'.$deletedBranch, GitHelper::ALLOW_DELETE)->shouldNotBeCalled();
         }
 
         return $helper;

--- a/tests/Command/Branch/BranchDeleteCommandTest.php
+++ b/tests/Command/Branch/BranchDeleteCommandTest.php
@@ -119,9 +119,9 @@ class BranchDeleteCommandTest extends CommandTestCase
         $helper->getActiveBranchName()->willReturn($branchName);
 
         if ($pushed) {
-            $helper->pushToRemote($remote, ':'.$deletedBranch, GitHelper::ALLOW_DELETE)->shouldBeCalled();
+            $helper->deleteRemoteBranch($remote, $deletedBranch)->shouldBeCalled();
         } else {
-            $helper->pushToRemote($remote, ':'.$deletedBranch, GitHelper::ALLOW_DELETE)->shouldNotBeCalled();
+            $helper->deleteRemoteBranch($remote, $deletedBranch)->shouldNotBeCalled();
         }
 
         return $helper;

--- a/tests/Command/Branch/BranchPushCommandTest.php
+++ b/tests/Command/Branch/BranchPushCommandTest.php
@@ -12,6 +12,7 @@
 namespace Gush\Tests\Command\Branch;
 
 use Gush\Command\Branch\BranchPushCommand;
+use Gush\Helper\GitHelper;
 use Gush\Tests\Command\CommandTestCase;
 use Symfony\Component\Console\Helper\HelperSet;
 
@@ -49,29 +50,7 @@ class BranchPushCommandTest extends CommandTestCase
             null,
             null,
             function (HelperSet $helperSet) {
-                $helperSet->set($this->getLocalGitHelper('cordoval', true)->reveal());
-            }
-        );
-
-        $tester->execute(['--set-upstream' => true]);
-
-        $display = $tester->getDisplay();
-
-        $this->assertCommandOutputMatches(
-            'Branch pushed to cordoval/'.self::TEST_BRANCH,
-            $display
-        );
-    }
-
-    public function testPushesBranchToForkWithForce()
-    {
-        $command = new BranchPushCommand();
-        $tester = $this->getCommandTester(
-            $command,
-            null,
-            null,
-            function (HelperSet $helperSet) {
-                $helperSet->set($this->getLocalGitHelper('cordoval', true)->reveal());
+                $helperSet->set($this->getLocalGitHelper('cordoval', GitHelper::SET_UPSTREAM)->reveal());
             }
         );
 
@@ -93,7 +72,29 @@ class BranchPushCommandTest extends CommandTestCase
             null,
             null,
             function (HelperSet $helperSet) {
-                $helperSet->set($this->getLocalGitHelper('someone', false, true)->reveal());
+                $helperSet->set($this->getLocalGitHelper('cordoval', GitHelper::SET_UPSTREAM)->reveal());
+            }
+        );
+
+        $tester->execute(['--set-upstream' => true]);
+
+        $display = $tester->getDisplay();
+
+        $this->assertCommandOutputMatches(
+            'Branch pushed to cordoval/'.self::TEST_BRANCH,
+            $display
+        );
+    }
+
+    public function testPushesBranchToForkWithForce()
+    {
+        $command = new BranchPushCommand();
+        $tester = $this->getCommandTester(
+            $command,
+            null,
+            null,
+            function (HelperSet $helperSet) {
+                $helperSet->set($this->getLocalGitHelper('someone', GitHelper::PUSH_FORCE)->reveal());
             }
         );
 
@@ -107,11 +108,11 @@ class BranchPushCommandTest extends CommandTestCase
         );
     }
 
-    private function getLocalGitHelper($org = 'cordoval', $upstream = false, $force = false)
+    private function getLocalGitHelper($org = 'cordoval', $options = 0)
     {
         $gitHelper = $this->getGitHelper();
         $gitHelper->getActiveBranchName()->willReturn(self::TEST_BRANCH);
-        $gitHelper->pushToRemote($org, self::TEST_BRANCH, $upstream, $force)->shouldBeCalled();
+        $gitHelper->pushToRemote($org, self::TEST_BRANCH, $options)->shouldBeCalled();
 
         return $gitHelper;
     }

--- a/tests/Command/PullRequest/PullRequestCreateCommandTest.php
+++ b/tests/Command/PullRequest/PullRequestCreateCommandTest.php
@@ -13,6 +13,7 @@ namespace Gush\Tests\Command\PullRequest;
 
 use Gush\Command\PullRequest\PullRequestCreateCommand;
 use Gush\Exception\UserException;
+use Gush\Helper\GitHelper;
 use Gush\Tests\Command\CommandTestCase;
 use Gush\Tests\Fixtures\Adapter\TestAdapter;
 use Prophecy\Argument;
@@ -369,7 +370,7 @@ class PullRequestCreateCommandTest extends CommandTestCase
         $helper->branchExists($branch)->will(
             function () use ($helper, $sourceOrg, $sourceRepo, $branch) {
                 $helper->remoteUpdate($sourceOrg)->shouldBeCalled();
-                $helper->pushToRemote($sourceOrg, $branch, true)->shouldBeCalled();
+                $helper->pushToRemote($sourceOrg, $branch, GitHelper::SET_UPSTREAM)->shouldBeCalled();
 
                 return true;
             }

--- a/tests/Command/PullRequest/PullRequestFixerCommandTest.php
+++ b/tests/Command/PullRequest/PullRequestFixerCommandTest.php
@@ -12,6 +12,7 @@
 namespace Gush\Tests\Command\PullRequest;
 
 use Gush\Command\PullRequest\PullRequestFixerCommand;
+use Gush\Helper\GitHelper;
 use Gush\Tests\Command\CommandTestCase;
 use Symfony\Component\Console\Helper\HelperSet;
 
@@ -88,20 +89,20 @@ class PullRequestFixerCommandTest extends CommandTestCase
 
         if ($wcReady) {
             $gitHelper->isWorkingTreeReady()->willReturn(true);
-            $gitHelper->commit('wip', ['a'])->shouldNotBeCalled();
+            $gitHelper->commit('wip', GitHelper::COMMIT_ALL)->shouldNotBeCalled();
         } else {
             $gitHelper->isWorkingTreeReady()->willReturn(false);
-            $gitHelper->commit('wip', ['a'])->shouldBeCalled();
+            $gitHelper->commit('wip', GitHelper::COMMIT_ALL)->shouldBeCalled();
         }
 
         $gitHelper->add('.')->shouldBeCalled();
 
         if ($hasChanges) {
             $gitHelper->isWorkingTreeReady(true)->willReturn(false);
-            $gitHelper->commit('cs-fixer', ['a'])->shouldBeCalled();
+            $gitHelper->commit('cs-fixer', GitHelper::COMMIT_ALL)->shouldBeCalled();
         } else {
             $gitHelper->isWorkingTreeReady(true)->willReturn(true);
-            $gitHelper->commit('cs-fixer', ['a'])->shouldNotBeCalled();
+            $gitHelper->commit('cs-fixer', GitHelper::COMMIT_ALL)->shouldNotBeCalled();
         }
 
         return $gitHelper;

--- a/tests/Command/PullRequest/PullRequestSquashCommandTest.php
+++ b/tests/Command/PullRequest/PullRequestSquashCommandTest.php
@@ -12,6 +12,7 @@
 namespace Gush\Tests\Command\PullRequest;
 
 use Gush\Command\PullRequest\PullRequestSquashCommand;
+use Gush\Helper\GitHelper;
 use Gush\Tests\Command\CommandTestCase;
 use Symfony\Component\Console\Helper\HelperSet;
 
@@ -148,8 +149,8 @@ class PullRequestSquashCommandTest extends CommandTestCase
         $helper->createTempBranch('head_ref')->willReturn('temp--head_ref');
         $helper->checkout('temp--head_ref', true)->shouldBeCalled();
 
-        $helper->squashCommits('gushphp/base_ref', 'temp--head_ref')->shouldBeCalled();
-        $helper->pushToRemote('cordoval', 'temp--head_ref:head_ref', false, true)->shouldBeCalled();
+        $helper->squashCommits('gushphp/base_ref', 'temp--head_ref', 0)->shouldBeCalled();
+        $helper->pushToRemote('cordoval', 'temp--head_ref:head_ref', GitHelper::PUSH_FORCE)->shouldBeCalled();
 
         $helper->branchExists('head_ref')->willReturn($branchExists);
 

--- a/tests/Helper/GitHelperTest.php
+++ b/tests/Helper/GitHelperTest.php
@@ -194,7 +194,6 @@ class GitHelperTest extends \PHPUnit_Framework_TestCase
     {
         $base = 'master';
         $sourceBranch = 'amazing-feature';
-        $hash = '8ae59958a2632018275b8db9590e9a79331030cb';
 
         $processHelper = $this->prophesize(ProcessHelper::class);
         $this->unitGit = new GitHelper(
@@ -207,9 +206,8 @@ class GitHelperTest extends \PHPUnit_Framework_TestCase
         $processHelper->runCommand('git rev-parse --abbrev-ref HEAD')->willReturn('master');
         $processHelper->runCommand(['git', 'checkout', 'master'])->shouldBeCalled();
         $processHelper->runCommand(['git', 'merge', '--ff', 'amazing-feature'])->shouldBeCalled();
-        $processHelper->runCommand('git rev-parse HEAD')->willReturn($hash);
 
-        $this->assertNull($this->unitGit->mergeBranch($base, $sourceBranch, null, true));
+        $this->assertNull($this->unitGit->mergeBranchFastForward($base, $sourceBranch));
     }
 
     /**

--- a/tests/Helper/GitHelperTest.php
+++ b/tests/Helper/GitHelperTest.php
@@ -217,7 +217,7 @@ class GitHelperTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(
             'RuntimeException',
-            'Push target ":master" does not include a local branch and deletion is not enabled, please report this bug!'
+            'Push target ":master" does not include a local branch, please report this bug!'
         );
 
         $this->unitGit->pushToRemote('my-org', ':master');
@@ -237,7 +237,7 @@ class GitHelperTest extends \PHPUnit_Framework_TestCase
             $this->filesystemHelper->reveal()
         );
 
-        $this->unitGit->pushToRemote('my-org', ':master', GitHelper::ALLOW_DELETE);
+        $this->unitGit->deleteRemoteBranch('my-org', 'master');
     }
 
     public function testBranchExists()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed Tickets |  |
| License | MIT |
- Replaces the usage unclear arguments with bitmasks instead
- Move undefinedToDefault outside the GitHelper

Todo:
- [x] fix tests
- [x] check and fix code usage
- [ ] test all affected commands manually (or write some smoke tests)
  - [x] BranchDeleteCommand
  - [x] BranchPushCommand
  - [x] PullRequestCreateCommand
  - [x] BranchMergeCommand
  - [x] BranchMergeCommand (with `--ff`) (**fixed**)
  - [x] PullRequestSquashCommand
  - [x] PullRequestFixerCommand

**Work in progress**
