### PR TITLE
Enable retrieval of Gitlab labels

### DIFF
--- a/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
@@ -12,8 +12,8 @@
 namespace Gush\ThirdParty\Gitlab\Adapter;
 
 use Gush\Adapter\BaseIssueTracker;
-use Gush\Exception\UnsupportedOperationException;
 use Gush\ThirdParty\Gitlab\Model\Issue;
+use Gush\Util\ArrayUtil;
 
 /**
  * @author Luis Cordova <cordoval@gmail.com>
@@ -179,7 +179,10 @@ class GitLabIssueTracker extends BaseIssueTracker
      */
     public function getLabels()
     {
-        throw new UnsupportedOperationException('Labels are not supported by Gitlab');
+        return ArrayUtil::getValuesFromNestedArray(
+            $this->client->api('projects')->labels($this->getCurrentProject()->id),
+            'name'
+        );
     }
 
     /**

--- a/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
@@ -33,6 +33,7 @@ class GitLabIssueTracker extends BaseIssueTracker
             $subject,
             [
                 'description' => $body,
+                'labels' => isset($options['labels']) ? implode(',', $options['labels']) : '',
             ]
         );
 

--- a/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
@@ -16,6 +16,7 @@ use Gush\Exception\UnsupportedOperationException;
 use Gush\ThirdParty\Gitlab\Model\Issue;
 use Gush\ThirdParty\Gitlab\Model\MergeRequest;
 use Gush\ThirdParty\Gitlab\Model\Project;
+use Gush\Util\ArrayUtil;
 
 /**
  * @author Luis Cordova <cordoval@gmail.com>
@@ -93,7 +94,10 @@ class GitLabRepoAdapter extends BaseAdapter
      */
     public function getLabels()
     {
-        throw new UnsupportedOperationException('Labels are not supported by Gitlab');
+        return ArrayUtil::getValuesFromNestedArray(
+            $this->client->api('projects')->labels($this->getCurrentProject()->id),
+            'name'
+        );
     }
 
     /**

--- a/src/ThirdParty/Gitlab/Model/Issue.php
+++ b/src/ThirdParty/Gitlab/Model/Issue.php
@@ -39,6 +39,10 @@ class Issue extends Model\Issue
                     $issue['number'] = $this->$property;
                     break;
 
+                case 'labels':
+                    $issue['labels'] = $this->$property;
+                    break;
+
                 case 'author':
                     $issue['user'] = $this->$property->username;
                     break;


### PR DESCRIPTION
Gitlab issue labels are disabled for the moment, with this PR labels are retrieved from the repo.