### PR TITLE
Fix the `getComments` method in BitbucketIssueTracker

### DIFF
--- a/src/ThirdParty/Bitbucket/BitbucketIssueTracker.php
+++ b/src/ThirdParty/Bitbucket/BitbucketIssueTracker.php
@@ -323,7 +323,7 @@ class BitbucketIssueTracker extends BaseIssueTracker
      */
     public function getComments($id)
     {
-        $response = $this->client->apiIssues()->all(
+        $response = $this->client->apiIssues()->comments()->all(
             $this->getUsername(),
             $this->getRepository(),
             $id


### PR DESCRIPTION
The function used to retrieve the list of issue comments was wrong because it retrieve the issue list instead of the comment list...