### PR TITLE
Add an option to display issue comments

### DIFF
--- a/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
@@ -200,6 +200,12 @@ class GitLabIssueTracker extends BaseIssueTracker
         array_map(function($comment) use (&$comments) {
             $comments[] = [
                 'id' => $comment->id,
+                'url' => sprintf(
+                    '%s/issues/%d/#note_%d',
+                    $this->getCurrentProject()->web_url,
+                    $comment->parent->iid,
+                    $comment->id
+                ),
                 'user' => ['login' => $comment->author->username],
                 'body' => $comment->body,
                 'created_at' => new \DateTime($comment->created_at),


### PR DESCRIPTION
The function used to retrieve the list of issue comments was wrong because it retrieve the issue list instead of the comment list...

Example of output :

```
Issue #2 (invalid): by xxx [xxx]
Type: Issue
Milestone: v0.0.1
Labels: enhancement, major, Bots activity, v0.0.1
Title: [issue title here]
Link: [issue url here]

**Objective:** To know the pace of crawl engines, and have a state of daily crawl.

Comments -------------------------------------------------------------------------------------------

Comment #14179448 by xxx on Tue, 09 Dec 2014 18:27:17 +0000
Link: [comment url here]

[comment body here]
----------
Comment #14153534 by xxx on Mon, 08 Dec 2014 19:46:18 +0000
Link: [comment url here]

[comment body here]
----------
```