### PR TITLE
Gitlab: Normalize comments and issues access

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ramsey/array_column": "~1.1.3",
         "gentle/bitbucket-api": "~0.5.2",
         "alexkovalevych/jira-api": "~1.0.7",
-        "m4tthumphrey/php-gitlab-api": "~7.11.0"
+        "m4tthumphrey/php-gitlab-api": "dev-master#5e506195028982ee08a01f31ee43d0db1e9b8d77"
     },
     "require-dev": {
         "mikey179/vfsStream": "~1.5.0"

--- a/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
@@ -196,7 +196,17 @@ class GitLabIssueTracker extends BaseIssueTracker
             $this->client->api('issues')->show($this->getCurrentProject()->id, $id)
         );
 
-        return $issue->showComments();
+        $comments = [];
+        array_map(function($comment) use (&$comments) {
+            $comments[] = [
+                'id' => $comment->id,
+                'user' => ['login' => $comment->author->username],
+                'body' => $comment->body,
+                'created_at' => new \DateTime($comment->created_at),
+            ];
+        }, $issue->showComments());
+
+        return $comments;
     }
 
     /**

--- a/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
@@ -63,11 +63,17 @@ class GitLabIssueTracker extends BaseIssueTracker
      */
     public function getIssue($id)
     {
-        return Issue::fromArray(
+        $issue = Issue::fromArray(
             $this->client,
             $this->getCurrentProject(),
             $this->client->api('issues')->show($this->getCurrentProject()->id, $id)
-        )->toArray();
+        );
+        $url = $this->getIssueUrl($issue);
+
+        $issue = $issue->toArray();
+        $issue['url'] = $url;
+
+        return $issue;
     }
 
     /**
@@ -80,7 +86,7 @@ class GitLabIssueTracker extends BaseIssueTracker
             $this->configuration['repo_domain_url'],
             $this->getUsername(),
             $this->getRepository(),
-            $this->getIssue($id)['iid']
+            ($id instanceof Issue)?$id->iid:$this->getIssue($id)['iid']
         );
     }
 

--- a/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
@@ -29,14 +29,14 @@ class GitLabIssueTracker extends BaseIssueTracker
      */
     public function openIssue($subject, $body, array $options = [])
     {
-        if (isset($options['assignee'])) {
+        if (!empty($options['assignee'])) {
             $assignee = $this->client->api('users')->search($options['assignee']);
             if (count($assignee) > 0) {
                 $assigneeId = current($assignee)['id'];
             }
         }
-        if (isset($options['milestone'])) {
-            $milestones = $this->client->api('milestones')->all($this->getCurrentProject()->id);
+        if (!empty($options['milestone'])) {
+            $milestones = $this->client->api('milestones')->all($this->getCurrentProject()->id, 1, 200);
             foreach ($milestones as $milestone) {
                 if ($milestone['title'] === $options['milestone']) {
                     $milestoneId = $milestone['id'];
@@ -49,7 +49,7 @@ class GitLabIssueTracker extends BaseIssueTracker
             $subject,
             [
                 'description' => $body,
-                'assignee_id' => isset($assigneeId) ? $assigneeId : null,
+                'assignee_id' => isset($assigneeId) ? $assigneeId : '',
                 'milestone_id' => isset($milestoneId) ? $milestoneId : null,
                 'labels' => isset($options['labels']) ? implode(',', $options['labels']) : '',
             ]
@@ -86,7 +86,7 @@ class GitLabIssueTracker extends BaseIssueTracker
             $this->configuration['repo_domain_url'],
             $this->getUsername(),
             $this->getRepository(),
-            ($id instanceof Issue)?$id->iid:$this->getIssue($id)['iid']
+            ($id instanceof Issue) ? $id->iid : $this->getIssue($id)['iid']
         );
     }
 

--- a/src/ThirdParty/Gitlab/Model/Issue.php
+++ b/src/ThirdParty/Gitlab/Model/Issue.php
@@ -63,7 +63,14 @@ class Issue extends Model\Issue
                 case 'updated_at':
                     $issue[$property] = new \DateTime($this->$property);
                     break;
-
+                case 'milestone':
+                    if (null !== $this->$property) {
+                        $tmp = $this->$property;
+                        $issue['milestone'] = $tmp['title'];
+                    } else {
+                        $issue['milestone'] = null;
+                    }
+                    break;
                 default:
                     $issue[$property] = $this->$property;
             }


### PR DESCRIPTION
The Gitlab API transform all the retrieved data into objects and :

* It was impossible to view issue detail
* It was impossible to view issue comments

This PR normalize the same way than on the others thirdparty libs.