### PR TITLE
[pull-request:create] Use `--base` option as default for `branch` template key

### DIFF
--- a/src/Helper/TemplateHelper.php
+++ b/src/Helper/TemplateHelper.php
@@ -163,6 +163,9 @@ class TemplateHelper extends Helper implements InputAwareInterface
                         $v = $editor->fromString('');
                     }
                 } else {
+                    if ('branch' === $key && $this->input->hasOption('base') && $this->input->getOption('base')) {
+                        $default = $this->input->getOption('base');
+                    }
                     $v = $this->style->ask($prompt.' ', $default);
                 }
             } else {


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no     |
|New feature? |yes     |
|BC breaks?   |no     |
|Deprecations?|no     |
|Tests pass?  |yes     |
|Fixed tickets|      |
|License      |MIT   |
|Doc PR       |      |
                      

**TODO:**
- [x] Add tests.