### PR TITLE
Remove caching of process result

### DIFF
--- a/src/Helper/GitConfigHelper.php
+++ b/src/Helper/GitConfigHelper.php
@@ -52,12 +52,12 @@ class GitConfigHelper extends Helper
     {
         $value = trim(
                 $this->processHelper->runCommand(
-                sprintf(
-                    'git config --%s --get %s',
-                    $section,
-                    $config
-                ),
-                true
+                    sprintf(
+                        'git config --%s --get %s',
+                        $section,
+                        $config
+                    ),
+                    true
             )
         );
 

--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -50,6 +50,8 @@ class GitHelper extends Helper
      */
     private $tempBranches = [];
 
+    private $topDir;
+
     public function __construct(
         ProcessHelper $processHelper,
         GitConfigHelper $gitConfigHelper,
@@ -134,17 +136,17 @@ class GitHelper extends Helper
      * @param bool $requireRoot Require folder is the root of the Git repository,
      *                          default is true.
      *
-     * @return bool Whether we are inside a git folder or not
+     * @return bool
      */
-    public function isGitFolder($requireRoot = true)
+    public function isGitDir($requireRoot = true)
     {
-        try {
-            $topFolder = $this->processHelper->runCommand(['git', 'rev-parse', '--show-toplevel']);
+        $folder = $this->getGitDir();
 
-            if ($requireRoot && str_replace('\\', '/', getcwd()) !== $topFolder) {
-                return false;
-            }
-        } catch (\RuntimeException $e) {
+        if ('' === $folder) {
+            return false;
+        }
+
+        if ($requireRoot && str_replace('\\', '/', getcwd()) !== $folder) {
             return false;
         }
 
@@ -714,5 +716,23 @@ class GitHelper extends Helper
         if (!$this->isWorkingTreeReady()) {
             throw new WorkingTreeIsNotReady();
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getGitDir()
+    {
+        if (null !== $this->topDir) {
+            return $this->topDir;
+        }
+
+        try {
+            $this->topDir = $this->processHelper->runCommand(['git', 'rev-parse', '--show-toplevel']);
+        } catch (\RuntimeException $e) {
+            $this->topDir = '';
+        }
+
+        return $this->topDir;
     }
 }

--- a/src/Subscriber/CoreInitSubscriber.php
+++ b/src/Subscriber/CoreInitSubscriber.php
@@ -104,7 +104,7 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
         ;
     }
 
-    /** 
+    /**
      * Use this for detecting the org and repo.
      *
      * Add the options to decorateDefinition.
@@ -119,7 +119,7 @@ class CoreInitSubscriber extends BaseGitRepoSubscriber
             return;
         }
 
-        if (!$this->gitHelper->isGitFolder()) {
+        if (!$this->gitHelper->isGitDir()) {
             throw new UserException(
                 sprintf(
                     'You can only run the "%s" command when you are in a Git directory.',

--- a/src/Subscriber/GitFolderSubscriber.php
+++ b/src/Subscriber/GitFolderSubscriber.php
@@ -44,7 +44,7 @@ class GitFolderSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!$this->gitHelper->isGitFolder()) {
+        if (!$this->gitHelper->isGitDir()) {
             throw new UserException(
                 sprintf(
                     'The "%s" command can only be executed from a the root of a Git repository.',

--- a/src/Subscriber/GitRepoSubscriber.php
+++ b/src/Subscriber/GitRepoSubscriber.php
@@ -173,7 +173,7 @@ class GitRepoSubscriber extends BaseGitRepoSubscriber
         // but warn its better to run "core:init" as this autodetection process
         // is much slower!
         if (null === $org || null === $repo) {
-            if (!$this->gitHelper->isGitFolder()) {
+            if (!$this->gitHelper->isGitDir()) {
                 throw new UserException(
                     'Provide the --org and --repo options when your are outside of a Git directory.'
                 );

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -148,13 +148,13 @@ class BaseTestCase extends \PHPUnit_Framework_TestCase
     /**
      * @return ObjectProphecy
      */
-    protected function getGitHelper($isGitFolder = true)
+    protected function getGitHelper($isGitDir = true)
     {
         $gitHelper = $this->prophesize('Gush\Helper\GitHelper');
         $gitHelper->setHelperSet(Argument::any())->willReturn();
         $gitHelper->clearTempBranches()->willReturn(null);
         $gitHelper->getName()->willReturn('git');
-        $gitHelper->isGitFolder()->willReturn($isGitFolder);
+        $gitHelper->isGitDir()->willReturn($isGitDir);
 
         return $gitHelper;
     }

--- a/tests/Command/Branch/BranchChangelogCommandTest.php
+++ b/tests/Command/Branch/BranchChangelogCommandTest.php
@@ -78,9 +78,9 @@ class BranchChangelogCommandTest extends CommandTestCase
         );
     }
 
-    protected function getGitHelper($isGitFolder = true, $hasTag = true)
+    protected function getGitHelper($isGitDir = true, $hasTag = true)
     {
-        $helper = parent::getGitHelper($isGitFolder);
+        $helper = parent::getGitHelper($isGitDir);
         $helper->getActiveBranchName()->willReturn('master');
 
         if ($hasTag) {

--- a/tests/Command/PullRequest/PullRequestSemVerCommandTest.php
+++ b/tests/Command/PullRequest/PullRequestSemVerCommandTest.php
@@ -63,9 +63,9 @@ class PullRequestSemVerCommandTest extends CommandTestCase
         return $helper;
     }
 
-    protected function getGitHelper($isGitFolder = true, $tag = 'v1.0.0')
+    protected function getGitHelper($isGitDir = true, $tag = 'v1.0.0')
     {
-        $helper = parent::getGitHelper($isGitFolder);
+        $helper = parent::getGitHelper($isGitDir);
         $helper->remoteUpdate('cordoval')->shouldBeCalled();
         $helper->getLastTagOnBranch('cordoval/head_ref')->willReturn($tag);
 

--- a/tests/Command/PullRequest/PullRequestSquashCommandTest.php
+++ b/tests/Command/PullRequest/PullRequestSquashCommandTest.php
@@ -136,9 +136,9 @@ class PullRequestSquashCommandTest extends CommandTestCase
         return $helper;
     }
 
-    protected function getGitHelper($isGitFolder = true, $branchExists = true, $localSync = true)
+    protected function getGitHelper($isGitDir = true, $branchExists = true, $localSync = true)
     {
-        $helper = parent::getGitHelper($isGitFolder);
+        $helper = parent::getGitHelper($isGitDir);
         $helper->remoteUpdate('gushphp')->shouldBeCalled();
         $helper->remoteUpdate('cordoval')->shouldBeCalled();
 

--- a/tests/Command/Util/MetaHeaderCommandTest.php
+++ b/tests/Command/Util/MetaHeaderCommandTest.php
@@ -223,7 +223,7 @@ OET;
         return new MetaHelper($metasSupported);
     }
 
-    protected function getGitHelper($isGitFolder = true)
+    protected function getGitHelper($isGitDir = true)
     {
         $files = [
             $this->srcDir.'/metatest.php',
@@ -232,7 +232,7 @@ OET;
             $this->srcDir.'/metatest.twig',
         ];
 
-        $helper = parent::getGitHelper($isGitFolder);
+        $helper = parent::getGitHelper($isGitDir);
         $helper->listFiles()->willReturn($files);
 
         return $helper;

--- a/tests/Helper/GitHelperTest.php
+++ b/tests/Helper/GitHelperTest.php
@@ -82,6 +82,40 @@ class GitHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function returns_this_project_has_git_enabled()
+    {
+        $this->assertTrue($this->git->isGitDir());
+        $this->assertTrue($this->git->isGitDir()); // check again because of internal state
+        $this->assertTrue($this->git->isGitDir(false));
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     */
+    public function returns_false_when_top_git_dir_was_expected()
+    {
+        chdir(__DIR__);
+
+        $this->assertFalse($this->git->isGitDir());
+        $this->assertTrue($this->git->isGitDir(false));
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     */
+    public function returns_false_for_non_git_dir()
+    {
+        chdir(sys_get_temp_dir());
+
+        $this->assertFalse($this->git->isGitDir());
+        $this->assertFalse($this->git->isGitDir(false));
+    }
+
+    /**
+     * @test
+     */
     public function gets_current_git_branch_name()
     {
         exec('git rev-parse --abbrev-ref HEAD', $output);

--- a/tests/Subscriber/GitFolderSubscriberTest.php
+++ b/tests/Subscriber/GitFolderSubscriberTest.php
@@ -36,7 +36,7 @@ class GitFolderSubscriberTest extends \PHPUnit_Framework_TestCase
         $subscriber = new GitFolderSubscriber($helper);
         $subscriber->initialize($commandEvent);
 
-        $this->assertTrue($helper->isGitFolder());
+        $this->assertTrue($helper->isGitDir());
     }
 
     /**
@@ -57,7 +57,7 @@ class GitFolderSubscriberTest extends \PHPUnit_Framework_TestCase
         $subscriber = new GitFolderSubscriber($helper);
         $subscriber->initialize($commandEvent);
 
-        $this->assertFalse($helper->isGitFolder());
+        $this->assertFalse($helper->isGitDir());
     }
 
     /**
@@ -82,10 +82,10 @@ class GitFolderSubscriberTest extends \PHPUnit_Framework_TestCase
         $subscriber->initialize($commandEvent);
     }
 
-    private function getGitHelper($isGitFolder = true)
+    private function getGitHelper($isGitDir = true)
     {
         $helper = $this->prophesize('Gush\Helper\GitHelper');
-        $helper->isGitFolder()->willReturn($isGitFolder);
+        $helper->isGitDir()->willReturn($isGitDir);
 
         return $helper->reveal();
     }


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Fixed tickets|   |
|License      |MIT|

Remove the caching of process result, this is only used by is `isGitFolder()`. Instead the `GitHelper` keeps the git-folder location itself (within the Helper class).

And add tests for `isGitFolder()`