### PR TITLE
Refactor ProcessHelper logic

### DIFF
--- a/src/Helper/EditorHelper.php
+++ b/src/Helper/EditorHelper.php
@@ -46,20 +46,13 @@ class EditorHelper extends Helper
             throw new \RuntimeException('No EDITOR environment variable set.');
         }
 
-        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $processHelper = $this->getHelperSet()->get('process');
-            /** @var ProcessHelper $processHelper */
-            $process = $processHelper->getProcessBuilder($editor.' '.escapeshellarg($tmpName))->getProcess();
-            $callback = $processHelper->wrapCallback($process);
+        $processHelper = $this->getHelperSet()->get('process');
 
-            $process->setTimeout(null);
-            $process->start($callback);
+        /** @var ProcessHelper $processHelper */
+        $process = $processHelper->getProcessBuilder($editor.' '.escapeshellarg($tmpName))->getProcess();
+        $process->setTimeout(null);
 
-            // Wait till editor closes
-            $process->wait();
-        } else {
-            system($editor.' '.$tmpName.' > `tty`');
-        }
+        $processHelper->runCommand($process, true);
 
         $contents = file_get_contents($tmpName);
         $fs->remove($tmpName);

--- a/src/Helper/EditorHelper.php
+++ b/src/Helper/EditorHelper.php
@@ -50,8 +50,10 @@ class EditorHelper extends Helper
             $processHelper = $this->getHelperSet()->get('process');
             /** @var ProcessHelper $processHelper */
             $process = $processHelper->getProcessBuilder($editor.' '.escapeshellarg($tmpName))->getProcess();
+            $callback = $processHelper->wrapCallback($process);
+
             $process->setTimeout(null);
-            $process->start();
+            $process->start($callback);
 
             // Wait till editor closes
             $process->wait();

--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -313,21 +313,8 @@ class GitHelper extends Helper
     public function getFirstCommitTitle($base, $sourceBranch)
     {
         try {
-            $forkPoint = $this->processHelper->runCommand(
-                sprintf(
-                    'git merge-base --fork-point %s %s',
-                    $base,
-                    $sourceBranch
-                )
-            );
-
-            $lines = $this->processHelper->runCommand(
-                sprintf(
-                    'git rev-list %s..%s --reverse --oneline',
-                    $forkPoint,
-                    $sourceBranch
-                )
-            );
+            $forkPoint = $this->processHelper->runCommand(['git', 'merge-base', '--fork-point', $base, $sourceBranch]);
+            $lines = $this->processHelper->runCommand(['git', 'rev-list', $forkPoint.'..'.$sourceBranch, '--reverse', '--oneline']);
 
             return substr(strtok($lines, "\n"), 8);
         } catch (\RuntimeException $e) {

--- a/src/Helper/ProcessHelper.php
+++ b/src/Helper/ProcessHelper.php
@@ -161,7 +161,7 @@ class ProcessHelper extends Helper implements OutputAwareInterface
      *
      * @return string[]
      */
-    protected function parseProcessArguments($command)
+    private function parseProcessArguments($command)
     {
         if (preg_match_all('/((?:"(?:(?:[^"\\\\]|\\\\.)+)")|(?:\'(?:[^\'\\\\]|\\\\.)+\')|[^ ]+)/i', $command, $args)) {
             $normalizeCommandArgument = function ($argument) {

--- a/tests/Helper/EditorHelperTest.php
+++ b/tests/Helper/EditorHelperTest.php
@@ -13,7 +13,9 @@ namespace Gush\Tests\Helper;
 
 use Gush\Helper\EditorHelper;
 use Gush\Helper\ProcessHelper;
+use Symfony\Component\Console\Helper\DebugFormatterHelper;
 use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 class EditorHelperTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,9 +23,15 @@ class EditorHelperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        $output = new BufferedOutput();
+
+        $processHelper = new ProcessHelper();
+        $processHelper->setOutput($output);
+
         $helperSet = new HelperSet(
             [
-                new ProcessHelper(),
+                new DebugFormatterHelper(),
+                $processHelper,
             ]
         );
 

--- a/tests/Helper/GitHelperTest.php
+++ b/tests/Helper/GitHelperTest.php
@@ -17,6 +17,9 @@ use Gush\Helper\GitHelper;
 use Gush\Helper\ProcessHelper;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Console\Helper\DebugFormatterHelper;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Output\NullOutput;
 
 class GitHelperTest extends \PHPUnit_Framework_TestCase
 {
@@ -61,14 +64,27 @@ class GitHelperTest extends \PHPUnit_Framework_TestCase
         $this->gitConfigHelper->setHelperSet(Argument::any());
         $this->gitConfigHelper->getName()->willReturn('git_config');
 
-        $this->realFsHelper = new FilesystemHelper();
+        $helperSet = new HelperSet(
+            [new DebugFormatterHelper()]
+        );
 
-        $this->git = new GitHelper(new ProcessHelper(), $this->gitConfigHelper->reveal(), $this->realFsHelper);
+        $this->realFsHelper = new FilesystemHelper();
+        $this->realFsHelper->setHelperSet($helperSet);
+
+        $processHelper = new ProcessHelper();
+        $processHelper->setHelperSet($helperSet);
+        $processHelper->setOutput(new NullOutput());
+
+        $this->git = new GitHelper($processHelper, $this->gitConfigHelper->reveal(), $this->realFsHelper);
+        $this->git->setHelperSet($helperSet);
+
         $this->unitGit = new GitHelper(
             $this->processHelper,
             $this->gitConfigHelper->reveal(),
             $this->filesystemHelper->reveal()
         );
+
+        $this->unitGit->setHelperSet($helperSet);
     }
 
     /**

--- a/tests/Helper/GitHelperTest.php
+++ b/tests/Helper/GitHelperTest.php
@@ -124,7 +124,9 @@ class GitHelperTest extends \PHPUnit_Framework_TestCase
     {
         chdir(sys_get_temp_dir());
 
-        $this->setExpectedExceptionRegExp('\RuntimeException', '#^fatal: Not a git repository \(or any of the parent directories\): \.git$#', 128);
+        $this->expectException('\RuntimeException');
+        $this->expectExceptionMessage('The command "\'git\' \'rev-parse\' \'--show-toplevel\'" failed', 128);
+
         $this->assertFalse($this->git->isGitDir());
     }
 

--- a/tests/Helper/ProcessHelperTest.php
+++ b/tests/Helper/ProcessHelperTest.php
@@ -12,6 +12,8 @@
 namespace Gush\Tests\Helper;
 
 use Gush\Helper\ProcessHelper;
+use Symfony\Component\Console\Helper\DebugFormatterHelper;
+use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 class ProcessHelperTest extends \PHPUnit_Framework_TestCase
@@ -20,8 +22,13 @@ class ProcessHelperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        $helperSet = new HelperSet(
+            [new DebugFormatterHelper()]
+        );
+
         $this->helper = new ProcessHelper();
         $this->helper->setOutput(new BufferedOutput());
+        $this->helper->setHelperSet($helperSet);
     }
 
     /**

--- a/tests/Helper/ProcessHelperTest.php
+++ b/tests/Helper/ProcessHelperTest.php
@@ -32,10 +32,19 @@ class ProcessHelperTest extends \PHPUnit_Framework_TestCase
         $this->helper->runCommands(
             [
                 [
-                    'line' => 'echo "hello"',
-                    'allow_failures' => true,
+                    'line' => ['echo', '"hello" it\'s me'],
+                    'allow_failures' => false,
                 ],
             ]
         );
+    }
+
+    /**
+     * @test
+     */
+    public function run_commands()
+    {
+        self::assertEquals('"hello" it\'s me', $this->helper->runCommand(['echo', '"hello" it\'s me']));
+        self::assertEquals('"hello" it\'s me', $this->helper->runCommand('echo "\"hello\" it\'s me"'));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets |  |
| License | MIT |

I refactored the ProcessHelper a little to make it cleaner and use existing techniques.
- Ensure command with dynamic values are provided as an array (no a string), to ensure they are properly escaped.
- Replace the home-made Console debugging with the Symfony ConsoleHelper version (which provides more information, the command (as it was executed, output, and success/failure)) (see image below).
- The EditorHelper now always uses the same logic (no more tty required), and shows which command is actually executed when debugging is enabled.

![schermafbeelding 2016-07-29 om 16 36 45](https://cloud.githubusercontent.com/assets/904790/17251883/bdf191b8-55aa-11e6-9da8-e34579509fec.png)
