### PR TITLE
Use mount-point for reading/writing configuration files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ RUN curl -s https://getcomposer.org/installer | php \
     && rm composer.phar \
     && rm composer.json
 
+RUN mkdir /root/project
+WORKDIR /root/project
+
 ENTRYPOINT ["/usr/src/gush/gush"]

--- a/gush
+++ b/gush
@@ -43,9 +43,9 @@ foreach ($adapters as $adapterName => $adapter) {
 }
 
 if (false !== getenv('GUSH_CONFIG')) {
-    $config = ConfigFactory::createConfigFromEnv((string) getenv('GUSH_CONFIG'), (string) getenv('GUSH_LOCAL_CONFIG'));
+    $config = ConfigFactory::createConfig((string) getenv('GUSH_CONFIG'), (string) getenv('GUSH_LOCAL_CONFIG'));
 } else {
-    $config = ConfigFactory::createConfig(getcwd());
+    $config = ConfigFactory::createConfig(null, getcwd());
 }
 
 (new Gush\Application($adapterFactory, $config))->run();

--- a/gush.dist
+++ b/gush.dist
@@ -4,6 +4,8 @@ docker run -it \
     -v ~/.ssh/id_rsa.pub:/root/.ssh/id_rsa.pub \
     -v ~/.ssh/id_rsa:/root/.ssh/id_rsa \
     -v ~/.ssh/known_hosts:/root/.ssh/known_hosts \
-    -e GUSH_CONFIG=`cat ~/.gush/.gush.yml | base64` \
-    -e GUSH_LOCAL_CONFIG=`cat $(pwd)/.gush.yml | base64` \
+    -v ~/.gush:/root/.gush \
+    -v "$(pwd)":/root/project \
+    -e GUSH_CONFIG=/root/.gush \
+    -e GUSH_LOCAL_CONFIG=/root/project \
     coder20078/gush "$@"

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -79,9 +79,12 @@ class ConfigFactory
      *
      * @return Config
      */
-    public static function createConfig($localHome = null)
+    public static function createConfig($home = null, $localHome = null)
     {
-        $home = static::getHomedir();
+        if (null === $home) {
+            $home = static::getHomedir();
+        }
+
         $cacheDir = self::getCacheDir($home);
         $localConfig = [];
 
@@ -92,39 +95,6 @@ class ConfigFactory
         }
 
         return new Config($home, $cacheDir, $systemConfig, $localHome, $localConfig);
-    }
-
-    /**
-     * Create a new Config object using the ENV configuration.
-     *
-     * Note that any missing config file is ignored.
-     *
-     * When the home or cache folder doesn't exist it's created.
-     * This also ensures the directories are protected from web access.
-     *
-     * @param string $systemConfigEnv
-     * @param string $localConfigEnv
-     *
-     * @return Config
-     */
-    public static function createConfigFromEnv($systemConfigEnv = null, $localConfigEnv = null)
-    {
-        $cacheDir = '/tmp';
-        $localHome = null;
-
-        $systemConfig = [];
-        $localConfig = [];
-
-        if (!empty($localConfigEnv)) {
-            $systemConfig = Yaml::parse((base64_decode($systemConfigEnv)));
-        }
-
-        if (!empty($localConfigEnv)) {
-            $localConfig = Yaml::parse((base64_decode($localConfigEnv)));
-            $localHome = 'env:';
-        }
-
-        return new Config('env:home', $cacheDir, $systemConfig, $localHome, $localConfig);
     }
 
     /**


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Fixed tickets|   |
|License      |MIT|
                   

Use the mount-points for reading and writting configuration. No more need to creazy hacks.