### PR TITLE
`docker-compose` isn't a requirement

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,10 @@
 
 machine:
   php:
-    version: 7.0.4
+    version: 7.0.7
   pre:
     - mkdir -p $HOME/docker
     - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
-    - sudo curl -L -o /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/1.6.0/docker-compose-`uname -s`-`uname -m`
-    - sudo chmod +x /usr/local/bin/docker-compose
   services:
     - docker
   environment:


### PR DESCRIPTION
|Q            |A   |
|---          |--- |
|Fixed tickets|#566|
|License      |MIT |