### PR TITLE
Use API for switching pull-request base

### DIFF
--- a/src/ThirdParty/Github/GitHubAdapter.php
+++ b/src/ThirdParty/Github/GitHubAdapter.php
@@ -484,7 +484,7 @@ class GitHubAdapter extends BaseAdapter implements IssueTracker, SupportsDynamic
     {
         $api = $this->client->api('pull_request');
 
-        $api->update(
+        return $api->update(
             $this->getUsername(),
             $this->getRepository(),
             $id,
@@ -623,6 +623,31 @@ class GitHubAdapter extends BaseAdapter implements IssueTracker, SupportsDynamic
         );
 
         return $asset['id'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function switchPullRequestBase($prNumber, $newBase, $newHead, $forceNewPr = false)
+    {
+        if ($forceNewPr) {
+            $pr = $this->getPullRequest($prNumber);
+
+            $newPr = $this->openPullRequest(
+                $newBase,
+                $newHead,
+                $pr['title'],
+                $pr['body']
+            );
+
+            $this->closePullRequest($prNumber);
+
+            return $newPr;
+        }
+
+        $pr = $this->updatePullRequest($prNumber, ['base' => $newBase]);
+
+        return ['number' => $prNumber, 'html_url' => $pr['html_url']];
     }
 
     protected function adaptIssueStructure(array $issue)

--- a/tests/Command/PullRequest/PullRequestSwitchBaseCommandTest.php
+++ b/tests/Command/PullRequest/PullRequestSwitchBaseCommandTest.php
@@ -48,7 +48,7 @@ class PullRequestSwitchBaseCommandTest extends CommandTestCase
             null,
             null,
             function (HelperSet $helperSet) {
-                $helperSet->set($this->getLocalGitHelper()->reveal());
+                $helperSet->set($this->getLocalGitHelper('develop', true)->reveal());
             }
         );
 
@@ -96,9 +96,25 @@ class PullRequestSwitchBaseCommandTest extends CommandTestCase
         );
     }
 
-    private function getLocalGitHelper($baseBranch = 'develop')
+    private function getLocalGitHelper($baseBranch = 'develop', $forceNew = false)
     {
         $helper = $this->getGitHelper();
+
+        if (!$forceNew) {
+            if ('base_ref' !== $baseBranch) {
+                $helper->remoteUpdate('cordoval')->shouldBeCalled();
+                $helper->remoteUpdate('gushphp')->shouldBeCalled();
+                $helper->switchBranchBase(
+                    'head_ref',
+                    'gushphp/base_ref',
+                    'gushphp/'.$baseBranch
+                )->shouldBeCalled();
+
+                $helper->pushToRemote('cordoval', 'head_ref', false, true)->shouldBeCalled();
+            }
+
+            return $helper;
+        }
 
         if ('base_ref' !== $baseBranch) {
             $helper->remoteUpdate('cordoval')->shouldBeCalled();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets |  |
| License | MIT |

GitHub has added support to allow switching the base of a pull-request (after creation!).
So no need to create a new pull-request anymore.

https://github.com/blog/2224-change-the-base-branch-of-a-pull-request
