### PR TITLE
Fix invalid milestone name retrieval

### DIFF
--- a/src/ThirdParty/Gitlab/Model/Issue.php
+++ b/src/ThirdParty/Gitlab/Model/Issue.php
@@ -64,12 +64,7 @@ class Issue extends Model\Issue
                     $issue[$property] = new \DateTime($this->$property);
                     break;
                 case 'milestone':
-                    if (null !== $this->$property) {
-                        $tmp = $this->$property;
-                        $issue['milestone'] = $tmp['title'];
-                    } else {
-                        $issue['milestone'] = null;
-                    }
+                    $issue['milestone'] = $this->$property;
                     break;
                 default:
                     $issue[$property] = $this->$property;


### PR DESCRIPTION
This is a little fix about API change in Gitlab. Before milestone details were retrieved as an array, now it's directly the label. I've just added a check on data type to avoid a warning.