### PR TITLE
Create a new command to show Pull Request details

### DIFF
--- a/src/Command/PullRequest/PullRequestShowCommand.php
+++ b/src/Command/PullRequest/PullRequestShowCommand.php
@@ -86,6 +86,10 @@ EOF
             )
         );
 
+        if ($pr['milestone'] && $pr['milestone'] instanceof Gitlab\Model\Milestone) {
+            $pr['milestone'] = $pr['milestone']->title;
+        }
+
         $styleHelper->detailsTable(
             [
                 ['Org/Repo', $input->getOption('org').'/'.$input->getOption('repo')],

--- a/tests/Command/PullRequest/PullRequestShowCommandTest.php
+++ b/tests/Command/PullRequest/PullRequestShowCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Tests\Command\PullRequest;
+
+use Gush\Command\PullRequest\PullRequestShowCommand;
+use Gush\Tests\Command\CommandTestCase;
+use Symfony\Component\Console\Helper\HelperSet;
+
+class PullRequestShowCommandTest extends CommandTestCase
+{
+    /**
+     * @test
+     */
+    public function it_shows_issue()
+    {
+        $tester = $this->getCommandTester($command = new PullRequestShowCommand());
+        $tester->execute(
+            [
+                'id' => 10
+            ]
+        );
+
+        $this->assertCommandOutputMatches(
+            [
+                'Pull Request #10 - Write a behat test to launch strategy by weaverryan [open]',
+                'Org/Repo: gushphp/gush',
+                'Link: https://github.com/gushphp/gush/pull/10',
+                'Labels: actionable, easy pick',
+                'Milestone: some_good_stuff',
+                'Assignee: cordoval',
+                'Source => Target: cordoval/gush#head_ref => gushphp/gush#base_ref'
+            ],
+            $tester->getDisplay()
+        );
+    }
+}


### PR DESCRIPTION
We have for the moment a `issue:show`, I think having a `pull-request:show` is nice too. It's the same logic than for issue :
- It display general details / description
- A flag `--with-comments` allow to display comments
- [x] Add tests
