### PR TITLE
Apply some normalization on Gitlab API handling

### DIFF
--- a/src/Command/Issue/IssueShowCommand.php
+++ b/src/Command/Issue/IssueShowCommand.php
@@ -60,9 +60,6 @@ EOF
         $comments = [];
         $tracker = $this->getIssueTracker();
         $issue = $tracker->getIssue($issueNumber);
-        if (true === $input->getOption('with-comments')) {
-            $comments = $tracker->getComments($issueNumber);
-        }
 
         $styleHelper = $this->getHelper('gush_style');
         $styleHelper->title(
@@ -89,20 +86,21 @@ EOF
         $styleHelper->section('Body');
         $styleHelper->text(explode("\n", $issue['body']));
 
-        if (true === $input->getOption('with-comments') && count($comments) > 0) {
+        if (true === $input->getOption('with-comments')) {
+            $comments = $tracker->getComments($issueNumber);
             $styleHelper->section('Comments');
             foreach ($comments as $comment) {
-                $styleHelper->listing([
-                    sprintf(
-                        'Comment #%s by %s on %s',
-                        $comment['id'],
-                        $comment['user'],
-                        $comment['created_at']->format('r')
-                    ),
-                    'Link: '.$comment['url'],
-                    '',
-                    wordwrap($comment['body'], 100),
+                $styleHelper->text(sprintf(
+                    '<fg=white>Comment #%s</> by %s on %s',
+                    $comment['id'],
+                    $comment['user'],
+                    empty($comment['created_at'])?'':$comment['created_at']->format('r')
+                ));
+                $styleHelper->detailsTable([
+                    ['Link', $comment['url']],
                 ]);
+                $styleHelper->text(explode("\n", wordwrap($comment['body'], 100)));
+                $styleHelper->text([]);
             }
         }
 

--- a/src/Command/Issue/IssueShowCommand.php
+++ b/src/Command/Issue/IssueShowCommand.php
@@ -12,9 +12,7 @@
 namespace Gush\Command\Issue;
 
 use Gush\Command\BaseCommand;
-use Gush\Exception\UserException;
 use Gush\Feature\IssueTrackerRepoFeature;
-use Gush\Helper\StyleHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -94,11 +92,9 @@ EOF
                     '<fg=white>Comment #%s</> by %s on %s',
                     $comment['id'],
                     $comment['user'],
-                    empty($comment['created_at'])?'':$comment['created_at']->format('r')
+                    $comment['created_at']->format('r')
                 ));
-                $styleHelper->detailsTable([
-                    ['Link', $comment['url']],
-                ]);
+                $styleHelper->detailsTable([['Link', $comment['url']]]);
                 $styleHelper->text(explode("\n", wordwrap($comment['body'], 100)));
                 $styleHelper->text([]);
             }

--- a/src/Command/PullRequest/PullRequestListCommand.php
+++ b/src/Command/PullRequest/PullRequestListCommand.php
@@ -47,7 +47,7 @@ class PullRequestListCommand extends BaseCommand implements TableFeature, GitRep
                 <<<EOF
 The <info>%command.name%</info> command lists all the pull requests:
 
-    <info>$ gush %command.name% 12</info>
+    <info>$ gush %command.name%</info>
 
 EOF
             )

--- a/src/Command/PullRequest/PullRequestListCommand.php
+++ b/src/Command/PullRequest/PullRequestListCommand.php
@@ -47,7 +47,7 @@ class PullRequestListCommand extends BaseCommand implements TableFeature, GitRep
                 <<<EOF
 The <info>%command.name%</info> command lists all the pull requests:
 
-    <info>$ gush %command.name%</info>
+    <info>$ gush %command.name% 12</info>
 
 EOF
             )

--- a/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
@@ -188,29 +188,22 @@ class GitLabIssueTracker extends BaseIssueTracker
      */
     public function getComments($id)
     {
-        $issue = Issue::fromArray(
-            $this->client,
-            $this->getCurrentProject(),
-            $this->client->api('issues')->show($this->getCurrentProject()->id, $id)
-        );
-
-        $comments = [];
-        array_map(function ($comment) use (&$comments) {
-            $comments[] = [
-                'id' => $comment->id,
+        $comments = $this->client->api('issues')->showComments($this->getCurrentProject()->id, $id);
+        return array_map(function ($comment) {
+            return [
+                'id' => $comment['id'],
                 'url' => sprintf(
                     '%s/issues/%d/#note_%d',
                     $this->getCurrentProject()->web_url,
-                    $comment->parent->iid,
-                    $comment->id
+                    $comment['parent']['iid'],
+                    $comment['id']
                 ),
-                'user' => ['login' => $comment->author->username],
-                'body' => $comment->body,
-                'created_at' => new \DateTime($comment->created_at),
+                'user' => $comment['author']['username'],
+                'body' => $comment['body'],
+                'created_at' => !empty($comment['created_at']) ? new \DateTime($comment['created_at']) : null,
+                'updated_at' => !empty($comment['updated_at']) ? new \DateTime($comment['updated_at']) : null,
             ];
-        }, $issue->showComments());
-
-        return $comments;
+        }, $comments);
     }
 
     /**

--- a/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
@@ -189,6 +189,7 @@ class GitLabIssueTracker extends BaseIssueTracker
     public function getComments($id)
     {
         $comments = $this->client->api('issues')->showComments($this->getCurrentProject()->id, $id);
+
         return array_map(function ($comment) {
             return [
                 'id' => $comment['id'],

--- a/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabIssueTracker.php
@@ -141,19 +141,19 @@ class GitLabIssueTracker extends BaseIssueTracker
      */
     public function updateIssue($id, array $parameters)
     {
-        $issue = $this->client->api('issues')->show($this->getCurrentProject()->id, $id);
-        $issue = Issue::fromArray($this->client, $this->getCurrentProject(), $issue);
-
         if (isset($parameters['assignee'])) {
             $assignee = $this->client->api('users')->search($parameters['assignee']);
-
             if (count($assignee) === 0) {
                 throw new \InvalidArgumentException(sprintf('Could not find user %s', $parameters['assignee']));
             }
 
-            $issue->update([
-                'assignee_id' => current($assignee)['id'],
-            ]);
+            $this->client
+                ->api('issues')
+                ->update(
+                    $this->getCurrentProject()->id,
+                    $id,
+                    ['assignee_id' => current($assignee)['id']]
+                );
         }
     }
 
@@ -162,9 +162,9 @@ class GitLabIssueTracker extends BaseIssueTracker
      */
     public function closeIssue($id)
     {
-        $issue = $this->client->api('issues')->show($this->getCurrentProject()->id, $id);
-
-        Issue::fromArray($this->client, $this->getCurrentProject(), $issue);
+        $this->client
+            ->api('issues')
+            ->update($this->getCurrentProject()->id, $id, ['state_event' => 'close']);
     }
 
     /**
@@ -172,15 +172,11 @@ class GitLabIssueTracker extends BaseIssueTracker
      */
     public function createComment($id, $message)
     {
-        $issue = Issue::fromArray(
-            $this->client,
-            $this->getCurrentProject(),
-            $this->client->api('issues')->show($this->getCurrentProject()->id, $id)
-        );
+        $comment = $this
+            ->api('issues')
+            ->addComment($this->getCurrentProject()->id, $id, ['body' => $message]);
 
-        $comment = $issue->addComment($message);
-
-        return sprintf('%s#note_%d', $this->getIssueUrl($id), $comment->id);
+        return sprintf('%s#note_%d', $this->getIssueUrl($id), $comment['id']);
     }
 
     /**

--- a/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
@@ -79,7 +79,8 @@ class GitLabRepoAdapter extends BaseAdapter
     public function getComments($id)
     {
         $comments = $this->client->api('merge_requests')->showNotes($this->getCurrentProject()->id, $id);
-        return array_filter(array_map(function($note) {
+
+        return array_filter(array_map(function ($note) {
             return [
                 'id' => $note['id'],
                 'user' => $note['author']['username'],
@@ -189,6 +190,7 @@ class GitLabRepoAdapter extends BaseAdapter
         );
         $data['milestone'] = $data['milestone']->title;
         $data['user'] = $data['author'];
+
         return $data;
     }
 


### PR DESCRIPTION
I've found that there are simpler methods to retrieve data from Gitlab API library than the one used for the moment.

Also, Gitlab API response structure is not the same than Github, some keys must be updated.