### PR TITLE
Add support for pullRequestGetCommits in GitlabRepoAdapter

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -308,6 +308,7 @@ LOGO;
             new Cmd\PullRequest\PullRequestMilestoneListCommand(),
             new Cmd\PullRequest\PullRequestFixerCommand(),
             new Cmd\PullRequest\PullRequestCheckoutCommand(),
+            new Cmd\PullRequest\PullRequestShowCommand(),
             new Cmd\Util\DocumentationCommand(),
             new Cmd\Util\StyleCIPatchCommand(),
             new Cmd\Util\MetaHeaderCommand(),

--- a/src/Command/PullRequest/PullRequestShowCommand.php
+++ b/src/Command/PullRequest/PullRequestShowCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Command\PullRequest;
+
+use Gush\Command\BaseCommand;
+use Gush\Exception\InvalidStateException;
+use Gush\Feature\GitRepoFeature;
+use Gush\Feature\TableFeature;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PullRequestShowCommand extends BaseCommand implements TableFeature, GitRepoFeature
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTableDefaultLayout()
+    {
+        return 'default';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pull-request:show')
+            ->addArgument(
+                'id',
+                InputArgument::REQUIRED,
+                'Identifier of the PR to retrieve'
+            )
+            ->addOption(
+                'with-comments',
+                null,
+                InputOption::VALUE_NONE,
+                'Display comments from this pull request'
+            )
+            ->setDescription('Retrieve detail for a specific pull request')
+            ->setHelp(
+                <<<EOF
+The <info>%command.name%</info> command retrieves details for a pull requests:
+
+    <info>$ gush %command.name%</info>
+
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $id = $input->getArgument('id');
+        $adapter = $this->getAdapter();
+        $pr = $adapter->getPullRequest($id);
+
+        $styleHelper = $this->getHelper('gush_style');
+        $styleHelper->title(
+            sprintf(
+                'Pull Request #%s - %s by %s [<fg='.'%s>%s</>]',
+                $pr['number'],
+                $pr['title'],
+                $pr['user'],
+                'closed' === $pr['state'] ? 'red' : 'green',
+                $pr['state']
+            )
+        );
+
+        $styleHelper->detailsTable(
+            [
+                ['Org/Repo', $input->getOption('org').'/'.$input->getOption('repo')],
+                ['Link', $pr['url']],
+                ['Labels', implode(', ', $pr['labels']) ?: '<comment>None</comment>'],
+                ['Milestone', $pr['milestone'] ?: '<comment>None</comment>'],
+                ['Assignee', $pr['assignee'] ?: '<comment>None</comment>'],
+                ['Source => Target', $pr['head']['user'].'/'.$pr['head']['repo'].'#'.$pr['head']['ref'].' => '.$pr['base']['user'].'/'.$pr['base']['repo'].'#'.$pr['base']['ref']],
+            ]
+        );
+
+        $styleHelper->section('Body');
+        $styleHelper->text(explode("\n", $pr['body']));
+
+        if (true === $input->getOption('with-comments')) {
+            $comments = $adapter->getComments($id);
+            $styleHelper->section('Comments');
+            foreach ($comments as $comment) {
+                $styleHelper->text(sprintf(
+                    '<fg=white>Comment #%s</> by %s on %s',
+                    $comment['id'],
+                    $comment['user'],
+                    empty($comment['created_at'])?'':$comment['created_at']->format('r')
+                ));
+                $styleHelper->detailsTable([
+                    ['Link', $comment['url']],
+                ]);
+                $styleHelper->text(explode("\n", wordwrap($comment['body'], 100)));
+                $styleHelper->text([]);
+            }
+        }
+
+        return self::COMMAND_SUCCESS;
+    }
+}

--- a/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
@@ -203,7 +203,15 @@ class GitLabRepoAdapter extends BaseAdapter
      */
     public function getPullRequestCommits($id)
     {
-        return [];
+        $commits = $this->client->api('merge_requests')->commits($this->getCurrentProject()->id, $id);
+        return array_map(function($commit) {
+            return [
+                'sha' => $commit['id'],
+                'short_sha' => $commit['short_id'],
+                'user' => $commit['author_name'].' <'.$commit['author_email'].'>',
+                'message' => trim($commit['message'])
+            ];
+        }, $commits);
     }
 
     /**

--- a/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
@@ -204,12 +204,13 @@ class GitLabRepoAdapter extends BaseAdapter
     public function getPullRequestCommits($id)
     {
         $commits = $this->client->api('merge_requests')->commits($this->getCurrentProject()->id, $id);
-        return array_map(function($commit) {
+
+        return array_map(function ($commit) {
             return [
                 'sha' => $commit['id'],
                 'short_sha' => $commit['short_id'],
                 'user' => $commit['author_name'].' <'.$commit['author_email'].'>',
-                'message' => trim($commit['message'])
+                'message' => trim($commit['message']),
             ];
         }, $commits);
     }


### PR DESCRIPTION
This PR is a WIP for the #581 issue. For the moment it can't be merged because the Gitlab API library can't retrieve merge request commits.

I've submitted a PR here: m4tthumphrey/php-gitlab-api#139.

When the PR will be merged and a version released, we can increment dependency number in composer.json and merge that one.

I've also added a new flag `--with-commits` on the `pull-request:show` command.
