### PR TITLE
Implement `branch:fork` for Gitlab adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "herrera-io/version": "~1.1.1",
         "ramsey/array_column": "~1.1.3",
         "gentle/bitbucket-api": "~0.5.2",
-        "m4tthumphrey/php-gitlab-api": "~7.13.1"
+        "m4tthumphrey/php-gitlab-api": "~7.14.0"
     },
     "require-dev": {
         "mikey179/vfsStream": "~1.5.0",

--- a/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
+++ b/src/ThirdParty/Gitlab/Adapter/GitLabRepoAdapter.php
@@ -37,7 +37,19 @@ class GitLabRepoAdapter extends BaseAdapter
      */
     public function createFork($org)
     {
-        throw new UnsupportedOperationException('Forking is not supported by Gitlab');
+        if ($this->configuration['authentication']['username'] !== $org) {
+            throw new UnsupportedOperationException(
+                'Gitlab can only fork repositories to currently logged in username'
+            );
+        }
+
+        $result = $this->client->api('projects')->fork($this->getCurrentProject()->id);
+
+        return [
+            'git_url' => $result['ssh_url_to_repo'],
+            'html_url' => $result['http_url_to_repo'],
+            'web_url' => $result['web_url'],
+        ];
     }
 
     public function getRepositoryInfo($org, $repository)


### PR DESCRIPTION
I've just implemented the branch forking feature for Gitlab adapter.

This PR rely on another PR : m4tthumphrey/php-gitlab-api/pull/140 because the forking feature is not possible in the current php-gitlab-api version.

When ready, I'll remove the WIP mention in the title...
