### PR TITLE
Allow a custom changelog format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "symfony/finder": "~2.8.0",
         "symfony/yaml": "~2.8.0",
         "symfony/event-dispatcher": "~2.8.0",
+        "twig/twig": "~1.26.1",
         "knplabs/github-api": "~1.3.1",
         "ddd/slug": "~1.0.0",
         "herrera-io/version": "~1.1.1",

--- a/src/Helper/TemplateRenderHelper.php
+++ b/src/Helper/TemplateRenderHelper.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types = 1);
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Helper;
+
+use Gush\Config;
+use Symfony\Component\Console\Helper\Helper;
+
+class TemplateRenderHelper extends Helper
+{
+    const TYPE_STRING = 'string';
+    const TYPE_FILE = 'file';
+
+    /**
+     * @var \Closure
+     */
+    private $twigServiceLoader;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var \Twig_Environment|null
+     */
+    private $twig;
+
+    /**
+     * Returns the canonical name of this helper.
+     *
+     * @return string The canonical name
+     */
+    public function getName()
+    {
+        return 'template_render';
+    }
+
+    public function __construct(\Closure $twigServiceLoader, Config $config)
+    {
+        $this->twigServiceLoader = $twigServiceLoader;
+        $this->config = $config;
+    }
+
+    /**
+     * Tries to find the template by name, and fallback to filename (system default).
+     *
+     * This method first looks if a template was configured in the local
+     * configuration, then fallback to the filename if none was configured.
+     *
+     * A local template is a string, rendered as-is.
+     *
+     * @param string      $templateName
+     * @param string|null $filename
+     *
+     * @return string The full location of the template.
+     */
+    public function findTemplate(string $templateName, string $filename = null): array
+    {
+        if (null === ($template = $this->config->get(['templates', $templateName], Config::CONFIG_LOCAL))) {
+            return ['@gush/'.$filename, self::TYPE_FILE];
+        }
+
+        return [$template, self::TYPE_STRING];
+    }
+
+    /**
+     * @param array $template [template filename/string, type]
+     * @param array $vars     Variables for the template
+     *
+     * @return string
+     */
+    public function renderTemplate(array $template, array $vars): string
+    {
+        if (self::TYPE_STRING === $template[1]) {
+            return $this->getTwig()->render('@gush/string_renderer.twig', ['template' => $template[0], 'vars' => $vars]);
+        }
+
+        return $this->getTwig()->render($template[0], $vars);
+    }
+
+    private function getTwig(): \Twig_Environment
+    {
+        if (null === $this->twig) {
+            $this->twig = ($this->twigServiceLoader)();
+        }
+
+        return $this->twig;
+    }
+}

--- a/src/Helper/TemplateRenderHelper.php
+++ b/src/Helper/TemplateRenderHelper.php
@@ -83,7 +83,7 @@ class TemplateRenderHelper extends Helper
     public function renderTemplate(array $template, array $vars): string
     {
         if (self::TYPE_STRING === $template[1]) {
-            return $this->getTwig()->render('@gush/string_renderer.twig', ['template' => $template[0], 'vars' => $vars]);
+            return $this->getTwig()->createTemplate($template[0])->render($vars);
         }
 
         return $this->getTwig()->render($template[0], $vars);

--- a/src/Resources/Templates/changelog.twig
+++ b/src/Resources/Templates/changelog.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+* {{ item.title }} ([{{ item.id }}]({{ item.url }}))
+{% endfor %}

--- a/src/Resources/Templates/string_renderer.twig
+++ b/src/Resources/Templates/string_renderer.twig
@@ -1,1 +1,0 @@
-{{ template_from_string(template).render(vars) }}

--- a/src/Resources/Templates/string_renderer.twig
+++ b/src/Resources/Templates/string_renderer.twig
@@ -1,0 +1,1 @@
+{{ template_from_string(template).render(vars) }}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | #540 #514 |
| License | MIT |

A custom changelog format, this is has been on my wish-list for to long, but I finally came-up
with something that solves my (and others) use-cases 😋

Instead of using a risky unreadable format like `%nn` (what is nn??)
I decided to use a fully-fledged Template engine, Twig to be exact.

But this is just the start, Gush has always been very opinionated about
which format we use for everything (pull-request merge message, changelog).
With this new system this is finally customizable, and performance is not affected
to much (Twig is lazy loaded).

Not only that, I have a great idea about a new feature (for which I will disclose
some more details soon. In short it's about keeping multiple repositories
common files (README, LICENSE, etc.) in sync (like Sonata-Devkit does).
Which will also use Twig for it's templates.
