### PR TITLE
Don’t use temp branch for PullRequestSquashCommand

### DIFF
--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -532,7 +532,7 @@ class GitHelper extends Helper
 
     public function pullRemote($remote, $ref = null)
     {
-        $command = ['git', 'pull', $remote];
+        $command = ['git', 'pull', '--rebase', $remote];
 
         if ($ref) {
             $command[] = $ref;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | #483 #519 |
| License | MIT |

This is an alternative approach for fixing #483, instead of what I did in #519 I choose a simpler approach. When the local branch exists use it (but ensure it's up-to-date, and fail when they have diverged) else checkout the remote branch.

BC break: the `--no-local-sync` option has been removed, as the local branch is now always used when present.

The tests works, but I need to do some manual testing to ensure nothing is broken 👍 
