### PR TITLE
Fix Meta for PHP files with declare

### DIFF
--- a/src/Helper/MetaHelper.php
+++ b/src/Helper/MetaHelper.php
@@ -181,9 +181,7 @@ class MetaHelper extends Helper
             $fileContent = implode("\n", $lines);
         }
 
-        $newContent = $startContent.$header.ltrim($fileContent);
-
-        return $newContent;
+        return $startContent.$header.ltrim($fileContent);
     }
 
     /**

--- a/src/Meta/Base.php
+++ b/src/Meta/Base.php
@@ -42,6 +42,6 @@ class Base implements Meta
      */
     public function getStartTokenRegex()
     {
-        return '{^(<\?(php)?\s+)|<%|(<\?xml[^>]+)}i';
+        return '{^(<\?(php)?\s+(?:declare\(\s*\w+\s*=\s*[\w\d\'"-]+\s*\);\s+)*)|<%|(<\?xml[^>]+)}is';
     }
 }

--- a/tests/Helper/MetaHelperTest.php
+++ b/tests/Helper/MetaHelperTest.php
@@ -12,6 +12,7 @@
 namespace Gush\Tests\Helper;
 
 use Gush\Helper\MetaHelper;
+use Gush\Meta\Base;
 use Gush\Meta\Meta;
 
 class MetaHelperTest extends \PHPUnit_Framework_TestCase
@@ -134,6 +135,60 @@ EOT;
         $this->assertEquals(ltrim($expected), $this->helper->updateContent($meta, self::$header, $input));
     }
 
+    public function testUpdateContentPhpFileWithNoHeaderAndStrictType()
+    {
+        $meta = $this->getMetaForPhp();
+
+        $input = <<<'EOT'
+<?php
+
+declare(strict_types = 1);
+
+namespace Test;
+
+class MetaTest
+{
+    private $test;
+
+    public function __construct($test)
+    {
+        $this->test = $test;
+    }
+}
+
+EOT;
+
+        $expected = <<<'EOT'
+<?php
+
+declare(strict_types = 1);
+
+/*
+ * This file is part of Your Package package.
+ *
+ * (c) 2009-2014 You <you@yourdomain.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Test;
+
+class MetaTest
+{
+    private $test;
+
+    public function __construct($test)
+    {
+        $this->test = $test;
+    }
+}
+
+EOT;
+
+        $this->assertEquals(ltrim($expected), $this->helper->updateContent($meta, self::$header, $input));
+    }
+
     public function testUpdateContentPhpFileWithHeader()
     {
         $meta = $this->getMetaForPhp();
@@ -160,6 +215,102 @@ EOT;
 
         $expected = <<<'EOT'
 <?php
+
+/*
+ * This file is part of Your Package package.
+ *
+ * (c) 2009-2014 You <you@yourdomain.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Tests\Tester;
+
+use Gush\Tester\HttpClient\TestHttpClient;
+
+EOT;
+
+        $this->assertEquals($expected, $this->helper->updateContent($meta, self::$header, $input));
+    }
+
+    public function testUpdateContentPhpFileWithHeaderWithStrictType()
+    {
+        $meta = $this->getMetaForPhp();
+
+        $input = <<<'EOT'
+<?php 
+
+declare(strict_types = 1);
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2014 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+
+
+namespace Gush\Tests\Tester;
+
+use Gush\Tester\HttpClient\TestHttpClient;
+
+EOT;
+
+        $expected = <<<'EOT'
+<?php 
+
+declare(strict_types = 1);
+
+/*
+ * This file is part of Your Package package.
+ *
+ * (c) 2009-2014 You <you@yourdomain.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Gush\Tests\Tester;
+
+use Gush\Tester\HttpClient\TestHttpClient;
+
+EOT;
+
+        $this->assertEquals($expected, $this->helper->updateContent($meta, self::$header, $input));
+    }
+
+    public function testUpdateContentPhpFileWithHeaderWithStrictTypeAndEncoding()
+    {
+        $meta = $this->getMetaForPhp();
+
+        $input = <<<'EOT'
+<?php declare(strict_types = 1);
+declare(encoding='ISO-8859-1');
+
+/*
+ * This file is part of Gush package.
+ *
+ * (c) 2013-2014 Luis Cordova <cordoval@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+
+
+namespace Gush\Tests\Tester;
+
+use Gush\Tester\HttpClient\TestHttpClient;
+
+EOT;
+
+        $expected = <<<'EOT'
+<?php declare(strict_types = 1);
+declare(encoding='ISO-8859-1');
 
 /*
  * This file is part of Your Package package.
@@ -256,37 +407,8 @@ EOT;
         ];
     }
 
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Gush\Meta\Meta
-     */
-    private function getMetaForPhp()
+    private function getMetaForPhp(): Base
     {
-        $meta = $this->createMock(Meta::class);
-
-        $meta
-            ->expects($this->any())
-            ->method('getStartDelimiter')
-            ->will($this->returnValue('/*'))
-        ;
-
-        $meta
-            ->expects($this->any())
-            ->method('getDelimiter')
-            ->will($this->returnValue('*'))
-        ;
-
-        $meta
-            ->expects($this->any())
-            ->method('getEndDelimiter')
-            ->will($this->returnValue('*/'))
-        ;
-
-        $meta
-            ->expects($this->any())
-            ->method('getStartTokenRegex')
-            ->will($this->returnValue('{^(<\?(php)?\s+)|<%|(<\?xml[^>]+)}i'))
-        ;
-
-        return $meta;
+        return new Base();
     }
 }


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Fixed tickets|   |
|License      |MIT|
                   

PHP 7 files should have a declare(strict_types=1); but this conflicts with the meta:header command 😅  so this fixes it, and allows any futue declare usage 👍