### PR TITLE
Fix subject extraction in `GitHelper::getFirstCommitTitle()`

### DIFF
--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -313,23 +313,10 @@ class GitHelper extends Helper
     public function getFirstCommitTitle($base, $sourceBranch)
     {
         try {
-            $forkPoint = $this->processHelper->runCommand(
-                sprintf(
-                    'git merge-base --fork-point %s %s',
-                    $base,
-                    $sourceBranch
-                )
-            );
+            $forkPoint = $this->processHelper->runCommand(['git', 'merge-base', '--fork-point', $base, $sourceBranch]);
+            $lines = $this->processHelper->runCommand(['git', 'rev-list', $forkPoint.'..'.$sourceBranch, '--reverse', '--oneline']);
 
-            $lines = $this->processHelper->runCommand(
-                sprintf(
-                    'git rev-list %s..%s --reverse --oneline',
-                    $forkPoint,
-                    $sourceBranch
-                )
-            );
-
-            return substr(strtok($lines, "\n"), 8);
+            return trim(strstr(strtok($lines, "\n"), ' '));
         } catch (\RuntimeException $e) {
             return '';
         }


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Fixed tickets|n/a|
|License      |MIT|

There was an issue regarding the hash longitude returned by `git rev-list {fork_point}..{source_branch} --reverse --oneline`. This change is maybe caused depending on the git version, so instead of count an arbitrary number of characters (formerly 8) to strip the hash, this now takes the first occurrence after a blank space.