### PR TITLE
[bugfix] Update `ConfigTest::provideInvalidValues()` in order to use installed requirement "ext-curl" instead of "ext-gd"

### DIFF
--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -249,7 +249,7 @@ class ConfigTest extends BaseTestCase
     {
         return [
             [new \stdClass()],
-            [imagecreate(1, 1)],
+            [curl_init()],
         ];
     }
 


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Fixed tickets|n/a|
|License      |MIT|